### PR TITLE
Add receipes for rules and phony targets

### DIFF
--- a/src/python/riemann/Makefile
+++ b/src/python/riemann/Makefile
@@ -1,79 +1,55 @@
-all:
-	make rp1_acoustics.so
-	make rp1_advection.so
-	make rp1_burgers.so 
-	make rp1_euler_with_efix.so
-	make rp1_nonlinear_elasticity_fwave.so 
-	make rp1_reactive_euler_with_efix.so 
-	make rp1_shallow_roe_with_efix.so 
-	make rp2_acoustics.so 
-	make rp2_advection.so 
-	make rp2_euler_5wave.so 
-	make rp2_euler_mapgrid.so 
-	make rp2_kpp.so 
-	make rp2_psystem.so 
-	make rp2_shallow_roe_with_efix.so 
-	make rp2_shallow_sphere.so 
-	make rp2_vc_acoustics.so 
-	make rp2_vc_advection.so 
-	make rp3_vc_acoustics.so 
-	make rp3acv.so
+# List of Solvers
+RIEMANN_SOLVERS = \
+	rp1_acoustics \
+	rp1_advection \
+	rp1_burgers \
+	rp1_euler_with_efix \
+	rp1_nonlinear_elasticity_fwave \
+	rp1_reactive_euler_with_efix \
+	rp1_shallow_roe_with_efix \
+	rp2_acoustics \
+	rp2_advection \
+	rp2_euler_5wave \
+	rp2_euler_mapgrid \
+	rp2_kpp \
+	rp2_psystem \
+	rp2_shallow_roe_with_efix \
+	rp2_shallow_sphere \
+	rp2_vc_acoustics \
+	rp2_vc_advection \
+	rp3_vc_acoustics \
+	rp3acv
+	
+SHARED_OBJECTS = $(addsuffix .so,$(RIEMANN_SOLVERS))
 
-rp1_acoustics.so: $(RIEMANN)/src/rp1_acoustics.f90
-	f2py -m rp1_acoustics -c  $(RIEMANN)/src/rp1_acoustics.f90
 
-rp1_advection.so: $(RIEMANN)/src/rp1_advection.f90
-	f2py -m rp1_advection -c  $(RIEMANN)/src/rp1_advection.f90
+# Generic targets
+rp1_%.so: $(RIEMANN)/src/rp1_%.f90
+	f2py -m $(basename $(notdir $@)) -c $^
 
-rp1_burgers.so: $(RIEMANN)/src/rp1_burgers.f90
-	f2py -m rp1_burgers -c  $(RIEMANN)/src/rp1_burgers.f90
+rp2_%.so: $(RIEMANN)/src/rpn2_%.f90 $(RIEMANN)/src/rpt2_%.f90
+	f2py -m $(basename $(notdir $@)) -c $^
 
-rp1_euler_with_efix.so: $(RIEMANN)/src/rp1_euler_with_efix.f90
-	f2py -m rp1_euler_with_efix -c  $(RIEMANN)/src/rp1_euler_with_efix.f90
+rp3_%.so: $(RIEMANN)/src/rpn3_%.f90 $(RIEMANN)/src/rpt3_%.f90 $(RIEMANN)/src/rptt3_%.f90
+	f2py -m $(basename $(notdir $@)) -c $^
+	
+# Phony targets
+.PHONY: all clean new
+all: $(SHARED_OBJECTS)
 
-rp1_nonlinear_elasticity_fwave.so: $(RIEMANN)/src/rp1_nonlinear_elasticity_fwave.f90
-	f2py -m rp1_nonlinear_elasticity_fwave -c  $(RIEMANN)/src/rp1_nonlinear_elasticity_fwave.f90
+clean:
+	-rm -f $(SHARED_OBJECTS)
+	
+new:
+	$(MAKE) clean
+	$(MAKE) all
 
-rp1_reactive_euler_with_efix.so: $(RIEMANN)/src/rp1_reactive_euler_with_efix.f90
-	f2py -m rp1_reactive_euler_with_efix -c  $(RIEMANN)/src/rp1_reactive_euler_with_efix.f90
-
-rp1_shallow_roe_with_efix.so: $(RIEMANN)/src/rp1_shallow_roe_with_efix.f90
-	f2py -m rp1_shallow_roe_with_efix -c  $(RIEMANN)/src/rp1_shallow_roe_with_efix.f90
-
-rp2_acoustics.so: $(RIEMANN)/src/rpn2_acoustics.f90 $(RIEMANN)/src/rpt2_acoustics.f90
-	f2py -m rp2_acoustics -c  $(RIEMANN)/src/rpn2_acoustics.f90 $(RIEMANN)/src/rpt2_acoustics.f90
-
-rp2_advection.so: $(RIEMANN)/src/rpn2_advection.f90 $(RIEMANN)/src/rpt2_advection.f90
-	f2py -m rp2_advection -c  $(RIEMANN)/src/rpn2_advection.f90 $(RIEMANN)/src/rpt2_advection.f90
-
-rp2_euler_5wave.so: $(RIEMANN)/src/rpn2_euler_5wave.f90 $(RIEMANN)/src/rpt2_euler_5wave.f90
-	f2py -m rp2_euler_5wave -c  $(RIEMANN)/src/rpn2_euler_5wave.f90 $(RIEMANN)/src/rpt2_euler_5wave.f90
+# Special rules	
+rp2_kpp.so: $(RIEMANN)/src/rpn2_kpp.f90 $(RIEMANN)/src/rpt2_dummy.f90
+	f2py -m $(basename $(notdir $@)) -c $^
 
 rp2_euler_mapgrid.so: $(RIEMANN)/src/rpn2_euler_mapgrid.f90 $(RIEMANN)/src/rpt2_euler_mapgrid.f90 $(RIEMANN)/src/euler_roe_solver_mapgrid.f90 $(RIEMANN)/src/getquadinfo_mapgrid.f90
-	f2py -m rp2_euler_mapgrid -c  $(RIEMANN)/src/rpn2_euler_mapgrid.f90 $(RIEMANN)/src/rpt2_euler_mapgrid.f90 $(RIEMANN)/src/euler_roe_solver_mapgrid.f90 $(RIEMANN)/src/getquadinfo_mapgrid.f90
-
-rp2_kpp.so: $(RIEMANN)/src/rpn2_kpp.f90 $(RIEMANN)/src/rpt2_dummy.f90
-	f2py -m rp2_kpp -c  $(RIEMANN)/src/rpn2_kpp.f90 $(RIEMANN)/src/rpt2_dummy.f90
-
-rp2_psystem.so: $(RIEMANN)/src/rpn2_psystem.f90 $(RIEMANN)/src/rpt2_psystem.f90
-	f2py -m rp2_psystem -c  $(RIEMANN)/src/rpn2_psystem.f90 $(RIEMANN)/src/rpt2_psystem.f90
-
-rp2_shallow_roe_with_efix.so: $(RIEMANN)/src/rpn2_shallow_roe_with_efix.f90 $(RIEMANN)/src/rpt2_shallow_roe_with_efix.f90
-	f2py -m rp2_shallow_roe_with_efix -c  $(RIEMANN)/src/rpn2_shallow_roe_with_efix.f90 $(RIEMANN)/src/rpt2_shallow_roe_with_efix.f90
-
-rp2_shallow_sphere.so: $(RIEMANN)/src/rpn2_shallow_sphere.f90 $(RIEMANN)/src/rpt2_shallow_sphere.f90
-	f2py -m rp2_shallow_sphere -c  $(RIEMANN)/src/rpn2_shallow_sphere.f90 $(RIEMANN)/src/rpt2_shallow_sphere.f90
-
-rp2_vc_acoustics.so: $(RIEMANN)/src/rpn2_vc_acoustics.f90 $(RIEMANN)/src/rpt2_vc_acoustics.f90
-	f2py -m rp2_vc_acoustics -c  $(RIEMANN)/src/rpn2_vc_acoustics.f90 $(RIEMANN)/src/rpt2_vc_acoustics.f90
-
-rp2_vc_advection.so: $(RIEMANN)/src/rpn2_vc_advection.f90 $(RIEMANN)/src/rpt2_vc_advection.f90
-	f2py -m rp2_vc_advection -c  $(RIEMANN)/src/rpn2_vc_advection.f90 $(RIEMANN)/src/rpt2_vc_advection.f90
-
-rp3_vc_acoustics.so: $(RIEMANN)/src/rpn3_vc_acoustics.f90 $(RIEMANN)/src/rpt3_vc_acoustics.f90  $(RIEMANN)/src/rptt3_vc_acoustics.f90 
-	f2py -m rp3_vc_acoustics -c  $(RIEMANN)/src/rpn3_vc_acoustics.f90 $(RIEMANN)/src/rpt3_vc_acoustics.f90 $(RIEMANN)/src/rptt3_vc_acoustics.f90
-
+	f2py -m $(basename $(notdir $@)) -c $^
+	
 rp3acv.so: $(RIEMANN)/src/rpn3acv.f90 $(RIEMANN)/src/rpt3acv.f90 $(RIEMANN)/src/rptt3acv.f90
-	f2py -m rp3acv -c $(RIEMANN)/src/rpn3acv.f90 $(RIEMANN)/src/rpt3acv.f90 $(RIEMANN)/src/rptt3acv.f90
-
-
+	f2py -m $(basename $(notdir $@)) -c $^


### PR DESCRIPTION
This pull request simplifies the Makefile responsible for building the modules containing the fortran modules for PyClaw.  It also adds additional phony targets for cleaning the the .so files and remaking all of them.  A few rules are still explicitly in the Makefile due to pattern inconsistencies.
