### PR TITLE
Remove common blocks from Riemann solvers where possible.

### DIFF
--- a/src/euler_roe_solver_mapgrid.f90
+++ b/src/euler_roe_solver_mapgrid.f90
@@ -7,14 +7,8 @@
     double precision :: a1, a2, a3, a4, a5
     double precision :: gamma, gamma1
     integer :: m, p, mu, mv, ixy, i, j, k, info
-    logical :: in_rpt
-
-    double precision :: dtcom, dxcom, dycom, tcom
-    integer :: icom, jcom
 
     common /param/ gamma, gamma1
-    common /comxyt/ dtcom,dxcom,dycom,tcom,icom,jcom
-    common /comrp/ in_rpt
 
 
     info = 0

--- a/src/rpn2_euler_4wave.f90
+++ b/src/rpn2_euler_4wave.f90
@@ -42,11 +42,12 @@
       dimension delta(4)
       logical efix
       common /cparam/  gamma
-      common /comroe/ u2v2(-6:maxm2+7), &
-            u(-6:maxm2+7),v(-6:maxm2+7),enth(-6:maxm2+7),a(-6:maxm2+7), &
-            g1a2(-6:maxm2+7),euv(-6:maxm2+7) 
 !
       data efix /.true./    !# use entropy fix for transonic rarefactions
+
+      double precision u2v2(-6:maxm2+7), &
+            u(-6:maxm2+7),v(-6:maxm2+7),enth(-6:maxm2+7),a(-6:maxm2+7), &
+            g1a2(-6:maxm2+7),euv(-6:maxm2+7) 
 !
       if (mbc > 7 .OR. maxm2 < maxm) then
          write(6,*) 'need to increase maxm2 or 7 in rpn'

--- a/src/rpn2_euler_mapgrid.f90
+++ b/src/rpn2_euler_mapgrid.f90
@@ -27,22 +27,15 @@
     double precision :: u, enth, delta(4), rho, v
     double precision :: wave_local(3,4), s_local(3),uv(2)
     double precision :: speeds(2,3), u2v2l, u2v2r
-    integer :: i, m, mw, mu, mv, ixy1
-    logical :: efix, in_rpt
+    integer :: i, m, mw, mu, mv, ixy1, info
+    logical :: efix
 
     integer :: mcapa,locrot, locarea
     double precision :: rot(4), area
 
-    double precision :: dtcom, dxcom, dycom, tcom
-    integer :: icom, jcom, info
-
-    common /comrp/ in_rpt
     common /param/  gamma,gamma1
-    common /comxyt/ dtcom,dxcom,dycom,tcom,icom,jcom
 
     data efix /.true./
-
-    in_rpt = .false.
 
     call get_aux_locations_n(ixy,mcapa,locrot,locarea)
 
@@ -89,12 +82,6 @@
             delta(m) = qr_state(m) - ql_state(m)
         enddo
 
-        if (ixy == 1) then
-            icom = i
-        else
-            jcom = i
-        endif
-
         ixy1 = 1
         call roe_solver(ixy1,uv,enth,delta,wave_local,s_local,info)
 
@@ -102,7 +89,6 @@
             write(6,*) 'ixy = ', ixy
             write(6,*) 'enth = ', enth
             write(6,*) 'Called from rpn2 '
-            write(6,*) 'i,j = ', icom, jcom
             write(6,*) ' '
             do m = 1,meqn
                 write(6,'(2E24.16)') ql_state(m), qr_state(m)

--- a/src/rpn2_shallow_roe_with_efix.f90
+++ b/src/rpn2_shallow_roe_with_efix.f90
@@ -44,11 +44,9 @@
     common /cparam/ grav
 
 !     # Roe averages quantities of each interface
-!     # These arrays are used afterwards in the transverse Riemann
-!     # solver, i.e. rpt2sw.f
     parameter (maxm2 = 1800)
-    common /comroe/ u(-6:maxm2+7),v(-6:maxm2+7),a(-6:maxm2+7), &
-    h(-6:maxm2+7)
+    double precision u(-6:maxm2+7),v(-6:maxm2+7),a(-6:maxm2+7), &
+                     h(-6:maxm2+7)
 
 
 !     local arrays
@@ -80,8 +78,6 @@
 
 
 !     # Compute the Roe-averaged variables needed in the Roe solver.
-!     # These are stored in the common block comroe since they are
-!     # later used in routine rpt2sh to do the transverse wave splitting.
 
     do 10 i = 2-mbc, mx+mbc
         h(i) = (qr(1,i-1)+ql(1,i))*0.50d0

--- a/src/rpn2_vc_acoustics.f90
+++ b/src/rpn2_vc_acoustics.f90
@@ -50,8 +50,6 @@
 !     ------------
     dimension delta(3)
 
-    common /comxyt/ dtcom,dxcom,dycom,tcom,icom,jcom
-
 !     # set mu to point to  the component of the system that corresponds
 !     # to velocity in the direction of this slice, mv to the orthogonal
 !     # velocity.

--- a/src/rpn3_euler.f90
+++ b/src/rpn3_euler.f90
@@ -34,18 +34,14 @@
       dimension auxl(maux, 1-mbc:maxm+mbc)
       dimension auxr(maux, 1-mbc:maxm+mbc)
 !
-!     local arrays -- common block comroe is passed to rpt3eu
-!
-!     ------------
       parameter (maxmrp = 1002)
       dimension delta(5)
       logical efix
 
-      common /comxyzt/ dtcom,dxcom,dycom,dzcom,tcom,icom,jcom,kcom
-      common /comroe/ u2v2w2(-1:maxmrp), &
+      double precision u2v2w2(-1:maxmrp), &
             u(-1:maxmrp),v(-1:maxmrp),w(-1:maxmrp),enth(-1:maxmrp), &
             a(-1:maxmrp),g1a2(-1:maxmrp),euv(-1:maxmrp)
-
+!
       common /cparam/ gamma
 !
       data efix /.true./    !# use entropy fix for transonic rarefactions
@@ -93,9 +89,6 @@
 !
 !
 !     # Compute the Roe-averaged variables needed in the Roe solver.
-!     # These are stored in the common block comroe since they are
-!     # later used in routine rpt3eu to do the transverse wave
-!     # splitting.
 !
       do 10 i = 2-mbc, mx+mbc
          if (qr(1,i-1) .le. 0.d0 .or. ql(1,i) .le. 0.d0) then
@@ -104,11 +97,11 @@
             write(*,990) (ql(j,i),j=1,5)
  990        format(5e12.4)
              if (ixyz .eq. 1) &
-               write(6,*) '*** rho .le. 0 in x-sweep at ',i,jcom,kcom
+               write(6,*) '*** rho .le. 0 in x-sweep at ',i
              if (ixyz .eq. 2) &
-               write(6,*) '*** rho .le. 0 in y-sweep at ',icom,i,kcom
+               write(6,*) '*** rho .le. 0 in y-sweep at ',i
              if (ixyz .eq. 3) &
-               write(6,*) '*** rho .le. 0 in z-sweep at ',icom,jcom,i
+               write(6,*) '*** rho .le. 0 in z-sweep at ',i
              write(6,*) 'stopped with rho < 0...'
              stop
              endif
@@ -128,11 +121,11 @@
          a2 = gamma1*(enth(i) - .5d0*u2v2w2(i))
          if (a2 .le. 0.d0) then
              if (ixyz .eq. 1) &
-               write(6,*) '*** a2 .le. 0 in x-sweep at ',i,jcom,kcom
+               write(6,*) '*** a2 .le. 0 in x-sweep at ',i
              if (ixyz .eq. 2) &
-               write(6,*) '*** a2 .le. 0 in y-sweep at ',icom,i,kcom
+               write(6,*) '*** a2 .le. 0 in y-sweep at ',i
              if (ixyz .eq. 3) &
-               write(6,*) '*** a2 .le. 0 in z-sweep at ',icom,jcom,i
+               write(6,*) '*** a2 .le. 0 in z-sweep at ',i
              write(6,*) 'stopped with a2 < 0...'
              stop
              endif

--- a/src/rpt2_euler.f90
+++ b/src/rpt2_euler.f90
@@ -23,10 +23,11 @@
       common /cparam/  gamma
       dimension waveb(4,3),sb(3)
       parameter (maxm2 = 1800)  !# assumes at most 200x200 grid with mbc=2
-      common /comroe/ u2v2(-6:maxm2+7), &
+!
+      double precision u2v2(-6:maxm2+7), &
             u(-6:maxm2+7),v(-6:maxm2+7),enth(-6:maxm2+7),a(-6:maxm2+7), &
             g1a2(-6:maxm2+7),euv(-6:maxm2+7) 
-!
+
       if (mbc > 7 .OR. maxm2 < maxm) then
          write(6,*) 'need to increase maxm2 or 7 in rpn'
          stop
@@ -41,6 +42,29 @@
           mu = 3
           mv = 2
         endif
+!
+!     # compute the Roe-averaged variables needed in the Roe solver.
+!     # These are stored in the common block comroe since they are
+!     # later used in routine rpt2eu to do the transverse wave splitting.
+!
+      do 10 i = 2-mbc, mx+mbc
+         rhsqrtl = dsqrt(qr(1,i-1))
+         rhsqrtr = dsqrt(ql(1,i))
+         pl = gamma1*(qr(4,i-1) - 0.5d0*(qr(2,i-1)**2 + &
+             qr(3,i-1)**2)/qr(1,i-1))
+         pr = gamma1*(ql(4,i) - 0.5d0*(ql(2,i)**2 + &
+             ql(3,i)**2)/ql(1,i))
+         rhsq2 = rhsqrtl + rhsqrtr
+         u(i) = (qr(mu,i-1)/rhsqrtl + ql(mu,i)/rhsqrtr) / rhsq2
+         v(i) = (qr(mv,i-1)/rhsqrtl + ql(mv,i)/rhsqrtr) / rhsq2
+         enth(i) = (((qr(4,i-1)+pl)/rhsqrtl &
+                  + (ql(4,i)+pr)/rhsqrtr)) / rhsq2
+         u2v2(i) = u(i)**2 + v(i)**2
+         a2 = gamma1*(enth(i) - .5d0*u2v2(i))
+         a(i) = dsqrt(a2)
+         g1a2(i) = gamma1 / a2
+         euv(i) = enth(i) - u2v2(i) 
+   10    continue
 !
          do 20 i = 2-mbc, mx+mbc
             a3 = g1a2(i) * (euv(i)*asdq(1,i) &
@@ -70,15 +94,15 @@
 !
 !           # compute the flux differences bmasdq and bpasdq
 !
-            do 10 m=1,meqn
+            do 30 m=1,meqn
                bmasdq(m,i) = 0.d0
                bpasdq(m,i) = 0.d0
-               do 10 mw=1,3
+               do 30 mw=1,3
                   bmasdq(m,i) = bmasdq(m,i) &
                               + dmin1(sb(mw), 0.d0) * waveb(m,mw)
                   bpasdq(m,i) = bpasdq(m,i) &
                               + dmax1(sb(mw), 0.d0) * waveb(m,mw)
-   10             continue
+   30             continue
 !                 
    20       continue
 !

--- a/src/rpt2_euler_mapgrid.f90
+++ b/src/rpt2_euler_mapgrid.f90
@@ -63,15 +63,12 @@
     double precision :: gamma, gamma1
 
     double precision :: dtcom, dxcom, dycom, tcom
-    integer :: icom, jcom, info
+    integer :: info
 
     logical :: in_rpt
 
     common /param/  gamma,gamma1
-    common /comxyt/ dtcom,dxcom,dycom,tcom,icom,jcom
-    common /comrp/ in_rpt
 
-    in_rpt = .true.
     useroe = .true.
 
     call get_aux_locations_t(ixy, mcapa, locrot,locarea)
@@ -160,18 +157,11 @@
         call roe_solver(ixy1,uvm_rot,enth,deltam, &
         wave_local,s_local,info)
 
-        if (ixy == 1) then
-            icom = i
-        else
-            jcom = i
-        endif
-
         if (info /= 0) then
             write(6,*) 'ixy = ', ixy
             write(6,*) 'ilr = ', ilr
             write(6,*) 'enth = ', enth
             write(6,*) 'Called from rpt2  (A-DQ)'
-            write(6,*) 'i,j = ', icom, jcom
             write(6,*) ' '
             write(6,'(24A,24A)') '        Left State      ', &
             '       Right State      '
@@ -209,7 +199,6 @@
             write(6,*) 'ilr = ', ilr
             write(6,*) 'enth = ', enth
             write(6,*) 'Called from rpt2  (A+DQ)'
-            write(6,*) 'i,j = ', icom, jcom
             write(6,*) ' '
             write(6,'(24A,24A)') '        Left State      ', &
             '       Right State      '

--- a/src/rpt3_euler.f90
+++ b/src/rpt3_euler.f90
@@ -7,10 +7,6 @@
 !     # Riemann solver in the transverse direction for the
 !     # Euler equations.
 !     #
-!     # Uses Roe averages and other quantities which were
-!     # computed in rpn3eu and stored in the common block comroe.
-!     #
-!     #
 !     # On input,
 !
 !     #    ql,qr is the data along some one-dimensional slice, as in rpn3
@@ -65,7 +61,7 @@
       parameter (maxmrp = 1002)
       integer tflag
 
-      common /comroe/ u2v2w2(-1:maxmrp), &
+      double precision u2v2w2(-1:maxmrp), &
             u(-1:maxmrp),v(-1:maxmrp),w(-1:maxmrp),enth(-1:maxmrp), &
             a(-1:maxmrp),g1a2(-1:maxmrp),euv(-1:maxmrp)
 !
@@ -90,6 +86,51 @@
 !
 !     # Solve Riemann problem in the second coordinate direction
 !
+      do 10 i = 2-mbc, mx+mbc
+         if (qr(1,i-1) .le. 0.d0 .or. ql(1,i) .le. 0.d0) then
+            write(*,*) i, mu, mv, mw
+            write(*,990) (qr(j,i-1),j=1,5)
+            write(*,990) (ql(j,i),j=1,5)
+ 990        format(5e12.4)
+             if (ixyz .eq. 1) &
+               write(6,*) '*** rho .le. 0 in x-sweep at ',i
+             if (ixyz .eq. 2) &
+               write(6,*) '*** rho .le. 0 in y-sweep at ',i
+             if (ixyz .eq. 3) &
+               write(6,*) '*** rho .le. 0 in z-sweep at ',i
+             write(6,*) 'stopped with rho < 0...'
+             stop
+             endif
+         rhsqrtl = dsqrt(qr(1,i-1))
+         rhsqrtr = dsqrt(ql(1,i))
+         pl = gamma1*(qr(5,i-1) - 0.5d0*(qr(mu,i-1)**2 + &
+                qr(mv,i-1)**2 + qr(mw,i-1)**2)/qr(1,i-1))
+         pr = gamma1*(ql(5,i) - 0.5d0*(ql(mu,i)**2 + &
+                ql(mv,i)**2 + ql(mw,i)**2)/ql(1,i))
+         rhsq2 = rhsqrtl + rhsqrtr
+         u(i) = (qr(mu,i-1)/rhsqrtl + ql(mu,i)/rhsqrtr) / rhsq2
+         v(i) = (qr(mv,i-1)/rhsqrtl + ql(mv,i)/rhsqrtr) / rhsq2
+         w(i) = (qr(mw,i-1)/rhsqrtl + ql(mw,i)/rhsqrtr) / rhsq2
+         enth(i) = (((qr(5,i-1)+pl)/rhsqrtl &
+                    + (ql(5,i)+pr)/rhsqrtr)) / rhsq2
+         u2v2w2(i) = u(i)**2 + v(i)**2 + w(i)**2
+         a2 = gamma1*(enth(i) - .5d0*u2v2w2(i))
+         if (a2 .le. 0.d0) then
+             if (ixyz .eq. 1) &
+               write(6,*) '*** a2 .le. 0 in x-sweep at ',i
+             if (ixyz .eq. 2) &
+               write(6,*) '*** a2 .le. 0 in y-sweep at ',i
+             if (ixyz .eq. 3) &
+               write(6,*) '*** a2 .le. 0 in z-sweep at ',i
+             write(6,*) 'stopped with a2 < 0...'
+             stop
+             endif
+         a(i) = dsqrt(a2)
+         g1a2(i) = gamma1 / a2
+         euv(i) = enth(i) - u2v2w2(i)
+   10 continue
+
+
       if( icoor .eq. 2 )then
 
       do 20 i = 2-mbc, mx+mbc


### PR DESCRIPTION
This pull request eliminates all common blocks for Roe averages, and almost all common blocks for dxcom, dycom.  It leaves common blocks that contain scalars -- for now -- since they are threadsafe.  It also leaves dxcom, dycom in mapped grid solvers, since we don't yet have another mechanism for passing those in.

PyClaw tests all pass.  Please test these with any other available tests from other packages.
