### PR TITLE
Remove gamma1 from rp3 Euler common block.

### DIFF
--- a/src/rpn3_euler.f90
+++ b/src/rpn3_euler.f90
@@ -41,8 +41,10 @@
       double precision u2v2w2(-1:maxmrp), &
             u(-1:maxmrp),v(-1:maxmrp),w(-1:maxmrp),enth(-1:maxmrp), &
             a(-1:maxmrp),g1a2(-1:maxmrp),euv(-1:maxmrp)
+
+      double precision gamma1
 !
-      common /cparam/ gamma, gamma1
+      common /cparam/ gamma
 !
       data efix /.true./    !# use entropy fix for transonic rarefactions
 !

--- a/src/rpt3_euler.f90
+++ b/src/rpt3_euler.f90
@@ -65,9 +65,11 @@
             u(-1:maxmrp),v(-1:maxmrp),w(-1:maxmrp),enth(-1:maxmrp), &
             a(-1:maxmrp),g1a2(-1:maxmrp),euv(-1:maxmrp)
 !
+      double precision gamma1
 
-      common /cparam/ gamma, gamma1
+      common /cparam/ gamma
 !
+      gamma1 = gamma - 1.d0
 
       if (-3.gt.1-mbc .or. maxmrp .lt. maxm+mbc) then
       write(6,*) 'need to increase maxmrp in rp3t'

--- a/src/rptt3_euler.f90
+++ b/src/rptt3_euler.f90
@@ -69,8 +69,11 @@
             u(-1:maxmrp),v(-1:maxmrp),w(-1:maxmrp),enth(-1:maxmrp), &
             a(-1:maxmrp),g1a2(-1:maxmrp),euv(-1:maxmrp)
 
-      common /cparam/ gamma, gamma1
+      double precision gamma1
+
+      common /cparam/ gamma
 !
+      gamma1 = gamma - 1.d0
 !
       if (-3.gt.1-mbc .or. maxmrp .lt. maxm+mbc) then
       write(6,*) 'need to increase maxmrp in rp3t'


### PR DESCRIPTION
Having gamma1 in the common block requires the user to correctly implement one line of the Riemann solver correctly every time they set up a problem that uses these solver.  This is fragile, promotes code duplication, and has no significant impact on performance.  So I've removed it.
