### PR TITLE
Correcting array dimension in mapped-grid Euler solver for consistency

### DIFF
--- a/src/rpn2_euler_mapgrid.f90
+++ b/src/rpn2_euler_mapgrid.f90
@@ -135,7 +135,7 @@ subroutine rpn2(ixy,maxm, meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,ap
     implicit none
 
     double precision :: ql(4), qr(4),wave_local(3,4)
-    double precision :: speeds(2,4), s1, s2, s3, s4
+    double precision :: speeds(2,3), s1, s2, s3, s4
     double precision :: sl, sml, smr, sr, qml(4),qmr(4)
     double precision :: ul, cl, ur, cr, pml, pmr, cml,cmr
     double precision :: sfract


### PR DESCRIPTION
Not much to say beyond the change description.  This got flagged by gfortran while I was using the mapped-grid Euler solver.
