### PR TITLE
Dont fail if layered shallow water solver won't compile

### DIFF
--- a/src/python/riemann/__init__.py
+++ b/src/python/riemann/__init__.py
@@ -53,7 +53,6 @@ except ImportError as e:
     traceback.print_exc()
     print "********************************************************************"
 
-try:
+import os
+if os.path.exists('./layered_shallow_water_1D.so'):
     import layered_shallow_water_1D
-except:
-    print 'Failed to import layered shallow water Riemann solver.'

--- a/src/python/riemann/setup.py
+++ b/src/python/riemann/setup.py
@@ -1,3 +1,8 @@
+# We don't compile the layered shallow water solver by default.
+# To compile it, do
+#
+# f2py -c ../../rp1_layered_shallow_water.f90 -m layered_shallow_water_1D
+
 one_d_riemann =   ['acoustics',
                    'advection',
                    'burgers',
@@ -39,6 +44,7 @@ def configuration(parent_package='',top_path=None):
     for rp in one_d_riemann:
         rp_ext = rp+'_1D'
         rp_src = [os.path.join(src_dir,'rp1_'+rp+'.f90')]
+        config.add_extension(rp_ext,rp_src)
 
     for rp in two_d_riemann:
         rp_ext = rp+'_2D'


### PR DESCRIPTION
I'm trying to fix #63, but this doesn't completely do the job.

I've made it so that if the layered Riemann solver didn't compile -- but all others did -- then you still get all the others on import.  I've also stopped providing default lapack/blas flags, and now we only pass the flags when compiling the layered solver. 

What's lacking -- and this is the most important part -- is how to keep the installer from exiting when the layered solver fails to compile.  Putting the config.add_extension() call in a try block does no good.  Numpy.distutils has defeated me here.  Any ideas?
