### PR TITLE
Update rpn3_euler.f90

### DIFF
--- a/src/rpn3_euler.f90
+++ b/src/rpn3_euler.f90
@@ -196,7 +196,7 @@
             amdq(m,i) = 0.d0
             apdq(m,i) = 0.d0
             do 90 mws=1,mwaves
-                if (s(m,iws) .lt. 0.d0) then
+                if (s(mws,i) .lt. 0.d0) then
                     amdq(m,i) = amdq(m,i) + s(mws,i)*wave(m,mws,i)
                 else
                     apdq(m,i) = apdq(m,i) + s(mws,i)*wave(m,mws,i)


### PR DESCRIPTION
Fixed a bug when efix=.false. resulting from uninitialized index variable.
