### PR TITLE
Compute gamma1 instead of loading it from a common block.

### DIFF
--- a/src/rp1_euler_with_efix.f90
+++ b/src/rp1_euler_with_efix.f90
@@ -39,9 +39,11 @@ subroutine rp1(maxmx,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
     dimension u(1-mbc:maxmx+mbc),enth(1-mbc:maxmx+mbc)
     dimension a(1-mbc:maxmx+mbc)
     logical :: efix
-    common /cparam/  gamma,gamma1
+    common /cparam/  gamma
 
     data efix /.true./    !# use entropy fix for transonic rarefactions
+
+    gamma1 = gamma - 1.d0
 
 !     # Compute Roe-averaged quantities:
 

--- a/src/rp1_reactive_euler_with_efix.f90
+++ b/src/rp1_reactive_euler_with_efix.f90
@@ -41,9 +41,11 @@ subroutine rp1(maxmx,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
     dimension u(1-mbc:maxmx+mbc),enth(1-mbc:maxmx+mbc)
     dimension a(1-mbc:maxmx+mbc)
     logical :: efix
-    common /cparam/  gamma,gamma1,qheat
+    common /cparam/  gamma, qheat
 
     data efix /.true./    !# use entropy fix for transonic rarefactions
+
+    gamma1 = gamma - 1.d0
 
 !     # Compute Roe-averaged quantities:
 

--- a/src/rpn2_euler_5wave.f90
+++ b/src/rpn2_euler_5wave.f90
@@ -65,7 +65,9 @@ subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apd
     ! Common block storage
     ! Ideal gas constant
     real(kind=8) :: gamma, gamma1
-    common /cparam/  gamma,gamma1
+    common /cparam/  gamma
+
+    gamma1 = gamma - 1.d0
 
     ! Set mu to point to  the component of the system that corresponds to 
     ! momentum in the direction of this slice, mv to the orthogonal momentum:

--- a/src/rpn2_euler_mapgrid.f90
+++ b/src/rpn2_euler_mapgrid.f90
@@ -41,9 +41,11 @@ subroutine rpn2(ixy,maxm, meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,ap
     integer :: mcapa,locrot, locarea
     double precision :: rot(4), area
 
-    common /param/  gamma,gamma1
+    common /param/  gamma
 
     data efix /.true./
+
+    gamma1 = gamma - 1.d0
 
     call get_aux_locations_n(ixy,mcapa,locrot,locarea)
 
@@ -155,7 +157,9 @@ subroutine rpn2(ixy,maxm, meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,ap
 
     integer :: m
 
-    common /param/ gamma, gamma1
+    common /param/ gamma
+
+    gamma1 = gamma - 1.d0
 
     s1 = speeds(1,1) + speeds(2,1)
     s2 = speeds(1,2) + speeds(2,2)

--- a/src/rpt2_euler_5wave.f90
+++ b/src/rpt2_euler_5wave.f90
@@ -31,7 +31,9 @@ subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux2,aux3,asdq,b
 
     ! Common block - ideal gas constant
     real(kind=8) :: gamma, gamma1
-    common /cparam/  gamma,gamma1
+    common /cparam/  gamma
+
+    gamma1 = gamma - 1.d0
 
     ! Initialize output
     bmasdq = 0.d0

--- a/src/rpt2_euler_mapgrid.f90
+++ b/src/rpt2_euler_mapgrid.f90
@@ -66,7 +66,9 @@ subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux2,aux3,asdq,b
 
     logical :: in_rpt
 
-    common /param/  gamma,gamma1
+    common /param/  gamma
+
+    gamma1 = gamma - 1.d0
 
     useroe = .true.
 


### PR DESCRIPTION
Fixes #79; see also https://github.com/clawpack/pyclaw/issues/447.

This will break tests since PyClaw examples need to be updated too.
