### PR TITLE
Fix important one-letter typo.

### DIFF
--- a/src/python/riemann/euler_with_efix_1D_constants.py
+++ b/src/python/riemann/euler_with_efix_1D_constants.py
@@ -2,4 +2,7 @@ num_waves = 3
 num_eqn   = 3
 
 # Conserved quantities
+density = 0
+momentum = 1
+energy = 2
 

--- a/src/rp1_euler_with_efix.f90
+++ b/src/rp1_euler_with_efix.f90
@@ -8,7 +8,7 @@ subroutine rp1(maxmx,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
 ! waves: 3
 ! equations: 3
 
-! Conserved quantites:
+! Conserved quantities:
 !       1 density
 !       2 momentum
 !       3 energy


### PR DESCRIPTION
A typo in the new header prevented my script from picking up the conserved quantity names for 1D Euler.
