### PR TITLE
Fix mislabeled common blocks for parameters

### DIFF
--- a/src/rpt3_burgers.f90
+++ b/src/rpt3_burgers.f90
@@ -58,7 +58,7 @@ subroutine rpt3(ixyz,icoor,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux2,aux3
     dimension   aux3(maux,1-mbc:maxm+mbc,3)
 
     double precision :: coeff
-    common /comrp/ coeff(3)
+    common /cparam/ coeff(3)
 
     integer :: i, iuvw
     double precision :: sb

--- a/src/rptt3_burgers.f90
+++ b/src/rptt3_burgers.f90
@@ -64,7 +64,7 @@ subroutine rptt3(ixyz,icoor,imp,impt,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux
     dimension     aux3(maux,1-mbc:maxm+mbc,3)
 
     double precision :: coeff
-    common /comrp/ coeff(3)
+    common /cparam/ coeff(3)
 
     integer :: iuvw, i
     double precision :: sc


### PR DESCRIPTION
Used in one of the AMRClaw examples (`burgers_3d_cubedata`) which also requires a rename of the common block in `setprob.f` (PR clawpack/amrclaw#111).
