### PR TITLE
Various point-wise Riemann solvers

### DIFF
--- a/src/rp1_acoustics_variable_ptwise.f90
+++ b/src/rp1_acoustics_variable_ptwise.f90
@@ -1,0 +1,81 @@
+! =====================================================
+subroutine rp1_ptwise(num_eqn, num_aux, num_waves, q_l, q_r, aux_l, aux_r,    &
+                       wave, s, amdq, apdq)
+! =====================================================
+
+!     # Pointwise Riemann solver for the acoustics equations in 1d, with
+!     #  variable coefficients (heterogeneous media)
+
+! waves:     2
+! equations: 2
+! aux fields: 2
+
+! Conserved quantities:
+!       1 pressure
+!       2 velocity
+
+! Auxiliary variables:
+!       1 impedance
+!       2 sound_speed
+
+!     # auxl(1,i) should contain the impedance Z in cell i
+!     # auxl(2,i) should contain the sound speed c in cell i
+
+!     # On input, q_l contains the state vector on the left
+!     #           q_r contains the state vector on the right
+
+!     # On output, wave contains the waves,
+!     #            s the speeds,
+!     #
+!     #            amdq = A^- Delta q,
+!     #            apdq = A^+ Delta q,
+!     #                   the decomposition of the flux difference
+!     #                       f(q_l) - f(q_r)
+!     #                   into leftgoing and rightgoing parts respectively.
+!     #
+
+
+    implicit none
+
+    ! Input Arguments
+    integer, intent(in) :: num_eqn, num_aux, num_waves
+    real(kind=8), intent(in out) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in out) :: aux_l(num_aux), aux_r(num_aux)
+
+    ! Output arguments
+    real(kind=8), intent(in out) :: wave(num_eqn, num_waves)
+    real(kind=8), intent(in out) :: s(num_waves)
+    real(kind=8), intent(in out) :: apdq(num_eqn), amdq(num_eqn)
+
+    ! Locals
+    real(kind=8) :: delta(2), a(2), zi, zim
+
+!   # Split the jump in q into waves:
+
+!   # Find a(1) and a(2), the coefficients of the 2 eigenvectors
+    delta = q_r - q_l
+
+!   # Impedances
+    zi = aux_r(1)
+    zim = aux_l(1)
+
+    a(1) = (-delta(1) + zi*delta(2)) / (zim + zi)
+    a(2) =  (delta(1) + zim*delta(2)) / (zim + zi)
+    
+!   # Compute the waves:
+    
+    wave(1,1) = -a(1)*zim
+    wave(2,1) = a(1)
+    s(1) = -aux_l(2)
+    
+    wave(1,2) = a(2)*zi
+    wave(2,2) = a(2)
+    s(2) = aux_r(2)
+
+!   # Compute the leftgoing and rightgoing fluctuations:
+!   # Note s(1,i) < 0 and s(2,i) > 0.
+
+    amdq = s(1)*wave(:,1)
+    apdq = s(2)*wave(:,2)
+
+    end subroutine rp1_ptwise

--- a/src/rp1_burgers_ptwise.f90
+++ b/src/rp1_burgers_ptwise.f90
@@ -1,0 +1,46 @@
+! =============================================================================
+subroutine rp1_ptwise(num_eqn, num_aux, num_waves, q_l, q_r, aux_l, aux_r,    &
+wave, s, amdq, apdq)
+! =============================================================================
+!
+! Riemann problems for the 1D Burgers' equation with entropy fix for 
+! transonic rarefaction. See "Finite Volume Method for Hyperbolic Problems",
+! R. J. LeVeque.
+
+! waves: 1
+! equations: 1
+
+! Conserved quantities:
+!       1 q
+    
+    implicit none
+
+    ! Input Arguments
+    integer, intent(in) :: num_eqn, num_aux, num_waves
+    real(kind=8), intent(in out) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in out) :: aux_l(num_aux), aux_r(num_aux)
+
+    ! Output arguments
+    real(kind=8), intent(in out) :: wave(num_eqn, num_waves)
+    real(kind=8), intent(in out) :: s(num_waves)
+    real(kind=8), intent(in out) :: apdq(num_eqn), amdq(num_eqn)
+
+    ! Local
+    logical :: efix
+ 
+    efix = .true.   !# Compute correct flux for transonic rarefactions
+
+    wave(1,1) = q_r(1) - q_l(1)
+    s(1) = 0.5d0 * (q_l(1) + q_r(1))
+
+    amdq(1) = dmin1(s(1), 0.d0) * wave(1,1)
+    apdq(1) = dmax1(s(1), 0.d0) * wave(1,1)
+
+    if (efix) then
+        if (q_r(1).gt.0.d0 .and. q_l(1).lt.0.d0) then
+            amdq(1) = - 1.d0/2.d0 * q_l(1)**2
+            apdq(1) =   1.d0/2.d0 * q_r(1)**2
+        endif
+    endif
+
+    end subroutine rp1_ptwise

--- a/src/rp1_ptwise.f90
+++ b/src/rp1_ptwise.f90
@@ -28,8 +28,8 @@ subroutine rp1(maxm, meqn, mwaves, maux, mbc, mx, ql, qr, auxl, auxr, wave, s, a
 
         call rp1_ptwise(meqn, maux, mwaves, qr(:, i - 1),       &
                                             ql(:, i),           &
-                                            auxr(:, i),         &
-                                            auxl(:, i - 1),     &
+                                            auxr(:, i - 1),         &
+                                            auxl(:, i),     &
                                             wave(:, :, i),      &
                                             s(:, i),            &
                                             amdq(:, i),         &

--- a/src/rpn2_advection_ptwise.f90
+++ b/src/rpn2_advection_ptwise.f90
@@ -1,0 +1,59 @@
+! =====================================================
+subroutine rpn2_ptwise(ixy, num_eqn, num_aux, num_waves, q_l, q_r,            &
+aux_l, aux_r, wave, s, amdq, apdq)
+! =====================================================
+
+! Riemann solver for the sample scalar equation
+!  q_t + u*q_x + v*q_y = 0
+
+! waves: 1
+! equations: 1
+
+! Conserved quantities:
+!       1 q
+
+! On input, ql contains the state vector at the left edge of each cell
+!           qr contains the state vector at the right edge of each cell
+
+! This data is along a slice in the x-direction if ixy=1
+!                            or the y-direction if ixy=2.
+! On output, wave contains the waves,
+!            s the speeds,
+!
+!            amdq = A^- Delta q,
+!            apdq = A^+ Delta q,
+!                   the decomposition of the flux difference
+!                       f(qr(i-1)) - f(ql(i))
+!                   into leftgoing and rightgoing parts respectively.
+!
+
+! maux=0 and aux arrays are unused in this example.
+
+    implicit none
+
+    ! Input
+    integer, intent(in) :: num_eqn, num_aux, num_waves, ixy
+    real(kind=8), intent(in) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in) :: aux_l(num_aux), aux_r(num_aux)
+
+    ! Output
+    real(kind=8), intent(in out) :: wave(num_eqn, num_waves)
+    real(kind=8), intent(in out) :: s(num_waves)
+    real(kind=8), intent(in out) :: apdq(num_eqn), amdq(num_eqn)
+
+    ! Common block
+    real(kind=8) :: u, v
+    common /cparam/ u, v
+
+    wave(1,1) = q_r(1) - q_l(1)
+    if (ixy == 1) then
+        s(1) = u
+    else
+        s(1) = v
+    endif
+    
+    ! Flux differences
+    amdq(1) = dmin1(s(1), 0.d0) * wave(1,1)
+    apdq(1) = dmax1(s(1), 0.d0) * wave(1,1)
+
+    end subroutine rpn2_ptwise

--- a/src/rpn2_vc_advection_ptwise.f90
+++ b/src/rpn2_vc_advection_ptwise.f90
@@ -1,0 +1,60 @@
+! =====================================================
+subroutine rpn2_ptwise(ixy, num_eqn, num_aux, num_waves, q_l, q_r,            &
+aux_l, aux_r, wave, s, amdq, apdq)
+! =====================================================
+! Riemann-solver for the advection equation
+!    q_t  +  u*q_x + v*q_y = 0
+! where u and v are a given velocity field.
+
+! waves: 1
+! equations: 1
+! aux fields: 2
+
+! Conserved quantities:
+!       1 q
+
+! Auxiliary variables:
+!         1  x_velocity
+!         2  y_velocity
+
+! solve Riemann problem along one slice of data.
+! This data is along a slice in the x-direction if ixy=1
+!                            or the y-direction if ixy=2.
+
+! On input, ql contains the state vector at the left edge of each cell
+!           qr contains the state vector at the right edge of each cell
+
+! On output, wave contains the waves, s the speeds,
+! and amdq, apdq the left-going and right-going flux differences,
+! respectively.  Note that in this advective form, the sum of
+! amdq and apdq is not equal to a difference of fluxes except in the
+! case of constant velocities.
+
+    implicit none
+
+    ! Input
+    integer, intent(in) :: num_eqn, num_aux, num_waves, ixy
+    real(kind=8), intent(in) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in) :: aux_l(num_aux), aux_r(num_aux)
+
+    ! Output
+    real(kind=8), intent(in out) :: wave(num_eqn, num_waves)
+    real(kind=8), intent(in out) :: s(num_waves)
+    real(kind=8), intent(in out) :: apdq(num_eqn), amdq(num_eqn)
+
+    ! Locals
+    integer :: normal_index, transverse_index
+    real(kind=8) :: delta(3), a(2)
+
+
+!     # Set wave, speed, and flux differences:
+!     ------------------------------------------
+
+        wave(1,1) = q_r(1) - q_l(1)
+        s(1) = aux_r(ixy)
+    !        # The flux difference df = s*wave  all goes in the downwind direction:
+        amdq(1) = dmin1(aux_r(ixy), 0.d0) * wave(1,1)
+        apdq(1) = dmax1(aux_r(ixy), 0.d0) * wave(1,1)
+
+    return
+    end subroutine rpn2_ptwise

--- a/src/rpt2_acoustics_ptwise.f90
+++ b/src/rpt2_acoustics_ptwise.f90
@@ -43,8 +43,8 @@ subroutine rpt2_ptwise(ixy, imp, num_eqn, num_aux, num_waves, q_l, q_r,      &
     bmasdq(transverse_index) = -cc * a(1)
 
     ! Up-going flux difference bpasdq is the product of c * wave
-    bmasdq(1) = cc * a(2) * zz
-    bmasdq(normal_index) = 0.d0
-    bmasdq(transverse_index) = cc * a(2)
+    bpasdq(1) = cc * a(2) * zz
+    bpasdq(normal_index) = 0.d0
+    bpasdq(transverse_index) = cc * a(2)
     
 end subroutine rpt2_ptwise

--- a/src/rpt2_advection_ptwise.f90
+++ b/src/rpt2_advection_ptwise.f90
@@ -1,0 +1,42 @@
+! =====================================================
+subroutine rpt2_ptwise(ixy, imp, num_eqn, num_aux, num_waves, q_l, q_r,      &
+aux_l, aux_r, asdq, bmasdq, bpasdq)
+! =====================================================
+
+!     # Riemann solver in the transverse direction for the scalar equation
+
+!     # Split asdq (= A^* \Delta q, where * = + or -)
+!     # into down-going flux difference bmasdq (= B^- A^* \Delta q)
+!     #    and up-going flux difference bpasdq (= B^+ A^* \Delta q)
+
+    implicit none
+
+    ! Input
+    integer, intent(in) :: num_eqn, num_aux, num_waves, ixy, imp
+    real(kind=8), intent(in) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in) :: aux_l(num_aux), aux_r(num_aux)
+    real(kind=8), intent(in out) :: asdq(num_eqn)
+
+    ! Output
+    real(kind=8), intent(in out) :: bmasdq(num_eqn), bpasdq(num_eqn)
+
+    ! Local
+    real(kind=8) :: stran
+
+    ! Common block
+    real(kind=8) :: u, v
+    common /cparam/ u, v
+
+!    # transverse wave speeds have been computed in rpn2
+!    # maux=0 and aux arrays are unused in this example.
+
+    if (ixy == 1) then
+        stran = v
+    else
+        stran = u
+    endif
+
+    bmasdq(1) = dmin1(stran, 0.d0) * asdq(1)
+    bpasdq(1) = dmax1(stran, 0.d0) * asdq(1)
+
+    end subroutine rpt2_ptwise

--- a/src/rpt2_vc_advection_ptwise.f90
+++ b/src/rpt2_vc_advection_ptwise.f90
@@ -1,0 +1,36 @@
+!     # Riemann solver in the transverse direction for the advection equation.
+
+! =====================================================
+subroutine rpt2_ptwise(ixy, imp, num_eqn, num_aux, num_waves, q_l, q_r,      &
+aux_l, aux_r, asdq, bmasdq, bpasdq)
+! =====================================================
+
+    implicit none
+
+    ! Input
+    integer, intent(in) :: num_eqn, num_aux, num_waves, ixy, imp
+    real(kind=8), intent(in) :: q_l(num_eqn), q_r(num_eqn)
+    real(kind=8), intent(in) :: aux_l(num_aux, 3), aux_r(num_aux, 3)
+    real(kind=8), intent(in out) :: asdq(num_eqn)
+
+    ! Output
+    real(kind=8), intent(in out) :: bmasdq(num_eqn), bpasdq(num_eqn)
+
+    ! Local
+    real(kind=8) :: aux(num_aux, 3)
+    integer :: kv
+
+    kv = 3-ixy  !#  = 1 if ixy=2  or  = 2 if ixy=1
+
+    !#  =  i-1 for amdq,  i for apdq
+    if (ixy == 1) then
+        aux = aux_l
+    else
+        aux = aux_r
+    endif
+
+    bmasdq(1) = dmin1(aux(kv,2), 0.d0) * asdq(1)
+    bpasdq(1) = dmax1(aux(kv,3), 0.d0) * asdq(1)
+
+    return
+    end subroutine rpt2_ptwise


### PR DESCRIPTION
rpn2_vc_advection_ptwise and rpt2_vc_advection_ptwise solvers working correctly on annulus examples in both classic and amrclaw repositories, but giving different results from the old Riemann solvers for the swirl example in the amrclaw repository.