### PR TITLE
Update to JCP GeoClaw Riemann solver

### DIFF
--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -36,6 +36,7 @@ c-----------------------------------------------------------------------
       double precision delh,delhu,delphi,delb,delnorm
       double precision rare1st,rare2st,sdelta,raremin,raremax
       double precision criticaltol,convergencetol,raretol
+      double precision criticaltol_2, hustar_interface
       double precision s1s2bar,s1s2tilde,hbar,hLstar,hRstar,hustar
       double precision huRstar,huLstar,uRstar,uLstar,hstarHLL
       double precision deldelh,deldelphi
@@ -109,7 +110,10 @@ c     !---------------------------------------------------
 
 
 c     !determine the steady state wave -------------------
-      criticaltol = 1.d-6
+      !criticaltol = 1.d-6
+      ! MODIFIED:
+      criticaltol = max(drytol*g, 1d-6)
+      criticaltol_2 = dsqrt(criticaltol)
       deldelh = -delb
       deldelphi = -g*0.5d0*(hR+hL)*delb
 
@@ -145,15 +149,16 @@ c           lambda(2) = max(min(0.5d0*(s1m+s2m),sE2),sE1)
          s1s2tilde= max(0.d0,uLstar*uRstar) - g*hbar
 
 c        !find if sonic problem
-         sonic=.false.
-         if (abs(s1s2bar).le.criticaltol) sonic=.true.
-         if (s1s2bar*s1s2tilde.le.criticaltol) sonic=.true.
-         if (s1s2bar*sE1*sE2.le.criticaltol) sonic = .true.
-         if (min(abs(sE1),abs(sE2)).lt.criticaltol) sonic=.true.
-         if (sE1.lt.0.d0.and.s1m.gt.0.d0) sonic = .true.
-         if (sE2.gt.0.d0.and.s2m.lt.0.d0) sonic = .true.
-         if ((uL+sqrt(g*hL))*(uR+sqrt(g*hR)).lt.0.d0) sonic=.true.
-         if ((uL-sqrt(g*hL))*(uR-sqrt(g*hR)).lt.0.d0) sonic=.true.
+         ! MODIFIED from 5.3.1 version
+         sonic = 
+     &     ((abs(s1s2bar).le.criticaltol) .or.
+     &      (s1s2bar*s1s2tilde.le.criticaltol*criticaltol) .or.
+     &      (s1s2bar*sE1*sE2.le.criticaltol*criticaltol) .or.
+     &      (min(abs(sE1),abs(sE2)).lt.criticaltol_2) .or.
+     &      (sE1.lt.criticaltol_2.and.s1m.gt. -criticaltol_2) .or.
+     &      (sE2.gt.-criticaltol_2.and.s2m.lt. criticaltol_2) .or.
+     &      ((uL+dsqrt(g*hL))*(uR+dsqrt(g*hR)).lt.0.d0) .or.
+     &      ((uL- dsqrt(g*hL))*(uR- dsqrt(g*hR)).lt.0.d0))
 
 c        !find jump in h, deldelh
          if (sonic) then

--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -259,9 +259,18 @@ c        !solve for beta(k) using Cramers Rule=================
          fw(3,mw)=beta(mw)*r(2,mw)
       enddo
       !find transverse components (ie huv jumps).
+      ! MODIFIED from 5.3.1 version
       fw(3,1)=fw(3,1)*vL
       fw(3,3)=fw(3,3)*vR
-      fw(3,2)= hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3)
+      fw(3,2)= 0.d0
+ 
+      hustar_interface = huL + fw(1,1)   ! = huR - fw(1,3)
+      if (hustar_interface <= 0.0d0) then
+          fw(3,1) = fw(3,1) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+        else
+          fw(3,3) = fw(3,3) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+        end if
+
 
       return
 


### PR DESCRIPTION
Some modifications proposed by Wenwen Li to deal with sonic point better and to properly handle transverse velocities.  I've been using this version on several problems recently and it seems fine, and works better in some cases.  

Note: These changes will cause some geoclaw regression tests to fail, so the regression data should be updated in geoclaw.

This may help with certain instability issues as in clawpack/geoclaw#209.

Some notes from her email to me:

---

GeoClaw uses the same threshold value ‘criticaltol’ for all criteria; however, ‘s1s2bar’ and ‘s1s2tilde’ have the unit of (m/s)^2, and sE1, sE2, s1m, s2m, uL and uR have the unit of m/s. So I think it might be better to use different threshold values for different lines. I propose to set the threshold values based on the value of sqrt(drytol*g) 

---

I had been noticing that there were horizontal/vertical lines in velocity and momentum plots for some tsunami scenarios --

When waves propagate from a deep cell towards a shallow cell (assuming huL > 0, huR > 0, hvL ≠ 0, hvR = 0), at the topo-jump interface, it is possible that s(1) < 0, s(2) < 0 and s(3) > 0. In GeoClaw Riemann solver, the hv component of all three fluxes Fw(1), Fw(2) and Fw(3) were calculated as below (a):

```
(a)
fw(3,1)=fw(3,1)*vL                            ! hv component of Fw(1)
fw(3,3)=fw(3,3)*vR                           ! hv component of Fw(3)
fw(3,2)= hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3)      ! hv component of Fw(2)
```

If vR==0, then the hv component of Fw(3) will always be zero, which means the hv component of the left cell cannot affect the right cell even if there should be mass transfer from left to right (since uL, vL > 0). Furthermore, as long as s(2) < 0, the value of hvL won’t affect the hv component of Fw(3), so it won’t affect the hv component of the right cell  at all, even if both uL and uR could be rightward. Thus the hv component will be trapped and accumulated at the left cell since there is incoming hv flux from the left but no outgoing hv flux.

The above issue is due to s(2) being not always in the same direction of real mass flux at the interface. Since s(2) is closely related to the calculations of flux for h and hu components, instead of changing s(2) itself, we could give a better estimation of real mass flux at the interface then distribute the hv flux component between fw(1) and fw(3) only.

In GeoClaw Riemann solver, the h flux component is zero for mid-wave (fw(2).h = 0) and Fw(1).h + F2(3).h  = huR – huL. (Fw(1).h is the mass growth rate at the left cell.) According to the mass conservation, the real mass excessive flux at the interface should be
Fw(real_mass) = huL + Fw(1).h = huR - Fw(3).h
So we may change the code (a) to (b):

```
(b)
fw(3,1)=fw(3,1)*vL
fw(3,3)=fw(3,3)*vR
fw(3,2)=0d0

hustar_interface = huL + fw(1,1)   ! or huR-fw(1,3)
if (hustar_interface <=0.0d0) then
                        fw(3,1) = fw(3,1) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3));
else
                        fw(3,3) = fw(3,3) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3));
end if
```
