### PR TITLE
Include pressure gradient source term in GeoClaw Riemann solver

### DIFF
--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -1,6 +1,6 @@
 c-----------------------------------------------------------------------
       subroutine riemann_aug_JCP(maxiter,meqn,mwaves,hL,hR,huL,huR,
-     &   hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)
+     &   hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,sw,fw)
 
       ! solve shallow water equations given single left and right states
       ! This solver is described in J. Comput. Phys. (6): 3089-3113, March 2008
@@ -12,7 +12,7 @@ c-----------------------------------------------------------------------
       ! instabilities that arise (with any solver) as flow becomes transcritical over variable topo
       ! due to loss of hyperbolicity.
 
-
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance
 
       implicit none
 
@@ -20,9 +20,8 @@ c-----------------------------------------------------------------------
       integer meqn,mwaves,maxiter
       double precision fw(meqn,mwaves)
       double precision sw(mwaves)
-      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,sE1,sE2
+      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,pR,pL,sE1,sE2
       double precision hvL,hvR,vL,vR
-      double precision drytol,g
 
 
       !local
@@ -38,21 +37,23 @@ c-----------------------------------------------------------------------
       double precision criticaltol,convergencetol,raretol
       double precision s1s2bar,s1s2tilde,hbar,hLstar,hRstar,hustar
       double precision huRstar,huLstar,uRstar,uLstar,hstarHLL
-      double precision deldelh,deldelphi
+      double precision deldelh,deldelphi,delp
       double precision s1m,s2m,hm
       double precision det1,det2,det3,determinant
 
       logical rare1,rare2,rarecorrector,rarecorrectortest,sonic
+
+      real(kind=8), parameter :: rho = 1025.d0
 
       !determine del vectors
       delh = hR-hL
       delhu = huR-huL
       delphi = phiR-phiL
       delb = bR-bL
+      delp = pR-pL
       delnorm = delh**2 + delphi**2
 
-      call riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2,
-     &                                          1,drytol,g)
+      call riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2,1)
 
 
       lambda(1)= min(sE1,s2m) !Modified Einfeldt speed
@@ -111,7 +112,7 @@ c     !---------------------------------------------------
 c     !determine the steady state wave -------------------
       criticaltol = 1.d-6
       deldelh = -delb
-      deldelphi = -g*0.5d0*(hR+hL)*delb
+      deldelphi = -0.5d0*(hR+hL)*(g*delb + delp / rho)
 
 c     !determine a few quanitites needed for steady state wave if iterated
       hLstar=hL
@@ -182,6 +183,7 @@ c        !find jump in phi, deldelphi
 c        !find bounds in case of critical state resonance, or negative states
          deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
          deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
+         deldelphi=deldelphi - hbar * delp / rho
 
          del(1)=delh-deldelh
          del(2)=delhu
@@ -265,19 +267,20 @@ c        !solve for beta(k) using Cramers Rule=================
 
 c-----------------------------------------------------------------------
       subroutine riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR,
-     &    hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)
+     &    hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,sw,fw)
 
       ! solve shallow water equations given single left and right states
       ! steady state wave is subtracted from delta [q,f]^T before decomposition
+
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance
 
       implicit none
 
       !input
       integer meqn,mwaves,maxiter
 
-      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,sE1,sE2
+      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,pR,pL,sE1,sE2
       double precision vL,vR,hvL,hvR
-      double precision drytol,g
 
       !local
       integer iter
@@ -287,7 +290,7 @@ c-----------------------------------------------------------------------
       double precision delh,delhu,delphi,delb,delhdecomp,delphidecomp
       double precision s1s2bar,s1s2tilde,hbar,hLstar,hRstar,hustar
       double precision uRstar,uLstar,hstarHLL
-      double precision deldelh,deldelphi
+      double precision deldelh,deldelphi,delp
       double precision alpha1,alpha2,beta1,beta2,delalpha1,delalpha2
       double precision criticaltol,convergencetol
       double precision sL,sR
@@ -296,17 +299,20 @@ c-----------------------------------------------------------------------
       double precision sw(mwaves)
       double precision fw(meqn,mwaves)
 
+      real(kind=8), parameter :: rho = 1025.d0
+
       !determine del vectors
       delh = hR-hL
       delhu = huR-huL
       delphi = phiR-phiL
       delb = bR-bL
+      delp = pR - pL
 
       convergencetol= 1.d-16
       criticaltol = 1.d-99
 
       deldelh = -delb
-      deldelphi = -g*0.5d0*(hR+hL)*delb
+      deldelphi = -0.5d0*(hR+hL)*(g * delb + delp / rho)
 
 !     !if no source term, skip determining steady state wave
       if (abs(delb).gt.0.d0) then
@@ -364,6 +370,7 @@ c           !find jump in phi, deldelphi
 !           !bounds in case of critical state resonance, or negative states
             deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
             deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
+            deldelphi=deldelphi - hbar * delp / rho
 
 !---------determine fwaves ------------------------------------------
 
@@ -450,28 +457,31 @@ c               hustar=huL+alpha1*sE1
 
 c-----------------------------------------------------------------------
       subroutine riemann_fwave(meqn,mwaves,hL,hR,huL,huR,hvL,hvR,
-     &            bL,bR,uL,uR,vL,vR,phiL,phiR,s1,s2,drytol,g,sw,fw)
+     &            bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,s1,s2,sw,fw)
 
       ! solve shallow water equations given single left and right states
       ! solution has two waves.
       ! flux - source is decomposed.
+
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance
 
       implicit none
 
       !input
       integer meqn,mwaves
 
-      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,s1,s2
-      double precision hvL,hvR,vL,vR
-      double precision drytol,g
+      real(kind=8), intent(in) :: hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR
+      real(kind=8), intent(in) :: hvL,hvR,vL,vR,pL,pR,s1,s2
 
-      double precision sw(mwaves)
-      double precision fw(meqn,mwaves)
+      real(kind=8), intent(inout) :: sw(mwaves)
+      real(kind=8), intent(inout) :: fw(meqn,mwaves)
 
       !local
       double precision delh,delhu,delphi,delb,delhdecomp,delphidecomp
-      double precision deldelh,deldelphi
+      double precision deldelh,deldelphi,delp
       double precision beta1,beta2
+
+      real(kind=8), parameter :: rho = 1025.d0
 
 
       !determine del vectors
@@ -479,8 +489,9 @@ c-----------------------------------------------------------------------
       delhu = huR-huL
       delphi = phiR-phiL
       delb = bR-bL
+      delp = pR - pL
 
-      deldelphi = -g*0.5d0*(hR+hL)*delb
+      deldelphi = -0.5d0*(hR+hL)*(g * delb + delp / rho)
       delphidecomp = delphi - deldelphi
 
       !flux decomposition
@@ -512,15 +523,16 @@ c-----------------------------------------------------------------------
 
 c=============================================================================
       subroutine riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2,
-     &             maxiter,drytol,g)
+     &             maxiter)
 
       !determine the Riemann structure (wave-type in each family)
 
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance
 
       implicit none
 
       !input
-      double precision hL,hR,uL,uR,drytol,g
+      double precision hL,hR,uL,uR
       integer maxiter
 
       !output

--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -50,7 +50,9 @@ c-----------------------------------------------------------------------
       delhu = huR-huL
       delphi = phiR-phiL
       delb = bR-bL
+#ifdef rp_pressure
       delp = pR-pL
+#endif
       delnorm = delh**2 + delphi**2
 
       call riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2,1)
@@ -112,7 +114,11 @@ c     !---------------------------------------------------
 c     !determine the steady state wave -------------------
       criticaltol = 1.d-6
       deldelh = -delb
+#ifdef rp_pressure      
       deldelphi = -0.5d0*(hR+hL)*(g*delb + delp / rho)
+#else
+      deldelphi = -0.5d0*(hR+hL)*g*delb
+#endif
 
 c     !determine a few quanitites needed for steady state wave if iterated
       hLstar=hL
@@ -183,7 +189,10 @@ c        !find jump in phi, deldelphi
 c        !find bounds in case of critical state resonance, or negative states
          deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
          deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
+
+#ifdef rp_pressure
          deldelphi=deldelphi - hbar * delp / rho
+#endif
 
          del(1)=delh-deldelh
          del(2)=delhu

--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -50,7 +50,7 @@ c-----------------------------------------------------------------------
       delhu = huR-huL
       delphi = phiR-phiL
       delb = bR-bL
-#ifdef rp_pressure
+#ifdef RP_PRESSURE
       delp = pR-pL
 #endif
       delnorm = delh**2 + delphi**2
@@ -114,7 +114,7 @@ c     !---------------------------------------------------
 c     !determine the steady state wave -------------------
       criticaltol = 1.d-6
       deldelh = -delb
-#ifdef rp_pressure      
+#ifdef RP_PRESSURE
       deldelphi = -0.5d0*(hR+hL)*(g*delb + delp / rho)
 #else
       deldelphi = -0.5d0*(hR+hL)*g*delb
@@ -190,7 +190,7 @@ c        !find bounds in case of critical state resonance, or negative states
          deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
          deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
 
-#ifdef rp_pressure
+#ifdef RP_PRESSURE
          deldelphi=deldelphi - hbar * delp / rho
 #endif
 


### PR DESCRIPTION
This PR includes terms in the Riemann solver so that it can compute the atmospheric pressure gradient source term in, for instance, storm surge or asteroid impact simulations (where this modification is actually critical).  This slightly modifies the `rpn2_geoclaw` Riemann solver and adds additional terms to the flux differences (similar to the bathymetry).  

This of course adds some overhead if you are not using the pressure source term.  Tests show that an increase in run time of about 1-2% for the JCP Riemann solver should be expected.  We could eliminate the additional work by using pre-processor directives (there is no difference then).

On the storm surge side the overall runtime decreases by about 15-20% overall in preliminary estimates.
