### PR TITLE
Include pressure gradient source term in GeoClaw into Riemann Solver

### DIFF
--- a/src/rpn2_geoclaw.f
+++ b/src/rpn2_geoclaw.f
@@ -33,7 +33,7 @@ c
 !           David George, Vancouver WA, Feb. 2009                           !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-      use geoclaw_module, only: g => grav, drytol => dry_tolerance
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance, rho
       use geoclaw_module, only: earth_radius, deg2rad
       use amr_module, only: mcapa
 
@@ -66,10 +66,6 @@ c
       double precision tw,dxdc
 
       logical rare1,rare2
-
-      ! Density used in pressure gradient calculation 
-      ! TODO - Should add this as a parameter to geoclaw_module
-      real(kind=8), parameter :: rho = 1025.d0
 
       ! In case there is no pressure forcing
       pL = 0.d0

--- a/src/rpn2_geoclaw.f
+++ b/src/rpn2_geoclaw.f
@@ -37,6 +37,8 @@ c
       use geoclaw_module, only: earth_radius, deg2rad
       use amr_module, only: mcapa
 
+      use storm_module, only: pressure_forcing, pressure_index
+
       implicit none
 
       !input
@@ -57,13 +59,21 @@ c
       double precision fw(3,3)
       double precision sw(3)
 
-      double precision hR,hL,huR,huL,uR,uL,hvR,hvL,vR,vL,phiR,phiL
+      double precision hR,hL,huR,huL,uR,uL,hvR,hvL,vR,vL,phiR,phiL,pL,pR
       double precision bR,bL,sL,sR,sRoe1,sRoe2,sE1,sE2,uhat,chat
       double precision s1m,s2m
       double precision hstar,hstartest,hstarHLL,sLtest,sRtest
       double precision tw,dxdc
 
       logical rare1,rare2
+
+      ! Density used in pressure gradient calculation 
+      ! TODO - Should add this as a parameter to geoclaw_module
+      real(kind=8), parameter :: rho = 1025.d0
+
+      ! In case there is no pressure forcing
+      pL = 0.d0
+      pR = 0.d0
 
       !loop through Riemann problems at each grid cell
       do i=2-mbc,mx+mbc
@@ -116,6 +126,10 @@ c        !set normal direction
          huR = ql(mu,i) 
          bL = auxr(1,i-1)
          bR = auxl(1,i)
+         if (pressure_forcing) then
+             pL = auxr(pressure_index, i-1)
+             pR = auxl(pressure_index, i)
+         end if
 
          hvL=qr(nv,i-1) 
          hvR=ql(nv,i)
@@ -204,14 +218,16 @@ c               bL=hstartest+bR
          maxiter = 1
 
          call riemann_aug_JCP(maxiter,3,3,hL,hR,huL,
-     &        huR,hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,
-     &                                    drytol,g,sw,fw)
+     &        huR,hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,
+     &                                    drytol,g,rho,sw,fw)
 
-c         call riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR,
-c     &     hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)
+C          call riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR,
+C      &     hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g,
+C      &     rho,sw,fw)
 
-c          call riemann_fwave(meqn,mwaves,hL,hR,huL,huR,hvL,hvR,
-c     &      bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)
+C          call riemann_fwave(meqn,mwaves,hL,hR,huL,huR,hvL,hvR,
+C      &      bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g,rho,sw,
+C      &      fw)
 
 c        !eliminate ghost fluxes for wall
          do mw=1,3

--- a/src/rpn2_layered_shallow_water.f90
+++ b/src/rpn2_layered_shallow_water.f90
@@ -49,10 +49,10 @@ subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,fwave,s,amdq,ap
 
     use amr_module, only: mcapa
 
-    use geoclaw_module, only: g => grav, pi, earth_radius
+    use geoclaw_module, only: g => grav, rho, pi, earth_radius
 
     use multilayer_module, only: num_layers, eigen_func
-    use multilayer_module, only: dry_tolerance, aux_layer_index, rho, r
+    use multilayer_module, only: dry_tolerance, aux_layer_index, r
     use multilayer_module, only: eigen_method, inundation_method
     use multilayer_module, only: eigen_func, inundation_eigen_func
 

--- a/src/rpn2_layered_shallow_water.f90
+++ b/src/rpn2_layered_shallow_water.f90
@@ -820,12 +820,19 @@ subroutine solve_single_layer_rp(layer_index, h_l, h_r, hu_l, hu_r, hv_l, hv_r, 
 
     ! Locals
     integer :: mw
-    real(kind=8) :: hL, hR, huL, huR, hvL, hvR, uL, uR, vL, vR, bL, bR
+    real(kind=8) :: hL, hR, huL, huR, hvL, hvR, uL, uR, vL, vR, bL, bR, pL, pR
     real(kind=8) :: phiL, phiR, wall(3), drytol
     real(kind=8) :: hstar, hstartest, s1m, s2m, rare1, rare2, sL, sR, uhat, chat, sRoe1, sRoe2, sE1, sE2
 
     ! Parameters (should be anyway)
     integer :: maxiter
+
+    ! Density used in pressure gradient calculation
+    ! This needs to be realistic here as compared to air density so we cannot
+    ! use what is stored in the multilayer_module unless real densities are 
+    ! being used
+    ! TODO - fix this limitation 
+    real(kind=8), parameter :: rho = 1025.d0
 
     drytol = dry_tolerance(layer_index)
 
@@ -837,6 +844,8 @@ subroutine solve_single_layer_rp(layer_index, h_l, h_r, hu_l, hu_r, hv_l, hv_r, 
     hvR = hv_r(layer_index)
     bL = b_l
     bR = b_r
+    pL = 0.d0
+    pR = 0.d0
 
     ! ========================================
     !  Begin Snipped Code From rpn2_geoclaw.f
@@ -923,7 +932,8 @@ subroutine solve_single_layer_rp(layer_index, h_l, h_r, hu_l, hu_r, hv_l, hv_r, 
          maxiter = 1
 
          call riemann_aug_JCP(maxiter,3,3,hL,hR,huL,huR,hvL,hvR,bL,bR,uL,uR, &
-                                          vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)
+                                          vL,vR,phiL,phiR,pL,pR,sE1,sE2,     &
+                                          drytol,g,rho,sw,fw)
 
 !         call riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR,
 !     &     hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,sE1,sE2,drytol,g,sw,fw)

--- a/src/rpt2_layered_shallow_water.f90
+++ b/src/rpt2_layered_shallow_water.f90
@@ -30,11 +30,11 @@ subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux2,aux3,asdq,b
 
     use amr_module, only: mcapa
     
-    use geoclaw_module, only: g => grav, earth_radius, pi
+    use geoclaw_module, only: g => grav, rho, earth_radius, pi
 
     use multilayer_module, only: num_layers, eigen_method, inundation_method
     use multilayer_module, only: eigen_func, inundation_eigen_func
-    use multilayer_module, only: dry_tolerance, rho, aux_layer_index
+    use multilayer_module, only: dry_tolerance, aux_layer_index
 
     implicit none
 


### PR DESCRIPTION
Add the gradient of pressure into the Riemann solver calculation rather than in the source term splitting.  This has important advantages when considering strong pressure gradients but also leads to significant speeds up to codes that use pressure gradient forcing (e.g. storm surge).

The corresponding GeoClaw PR is clawpack/geoclaw#242.