### PR TITLE
Switch back to using f-waves in variable-speed traffic solvers.

### DIFF
--- a/src/rp1_traffic_vc.f90
+++ b/src/rp1_traffic_vc.f90
@@ -19,7 +19,7 @@
 ! of the Riemann solver API.
 
 subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
-               ql,qr,auxl,auxr,wave,s,amdq,apdq)
+               ql,qr,auxl,auxr,fwave,s,amdq,apdq)
 
     implicit none
     ! Inputs
@@ -28,11 +28,11 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
     double precision, intent(in), dimension(num_aux, 1-num_ghost:maxm+num_ghost) :: auxl,auxr
     ! Outputs
     double precision, intent(out) :: s(num_waves,1-num_ghost:num_cells+num_ghost)
-    double precision, intent(out) :: wave(num_eqn,num_waves,1-num_ghost:num_cells+num_ghost)
+    double precision, intent(out) :: fwave(num_eqn,num_waves,1-num_ghost:num_cells+num_ghost)
     double precision, intent(out), dimension(num_eqn, 1-num_ghost:maxm+num_ghost) :: amdq,apdq
     ! Locals
     integer :: i
-    double precision :: fim1, fi, sim1, si, f0, fluxdiff
+    double precision :: fim1, fi, sim1, si, f0
 
     do i = 2-num_ghost, num_cells+num_ghost
         ! Compute the wave and speed, and fluctuations
@@ -40,8 +40,7 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         ! compute flux in each cell and flux difference:
         fim1 = auxr(1,i-1)*qr(1,i-1)*(1.d0 - qr(1,i-1))
         fi   = auxl(1,i  )*ql(1,i  )*(1.d0 - ql(1,i  ))
-        fluxdiff = fi - fim1
-        wave(1,1,i) = ql(1,i) - qr(1,i-1)
+        fwave(1,1,i) = fi - fim1
 
         ! compute characteristic speed in each cell:
         sim1 = auxr(1,i-1)*(1.d0 - 2.d0*qr(1,i-1))
@@ -50,13 +49,13 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         if (sim1 .lt. 0.d0 .and. si .le. 0.d0) then
             ! left-going
             s(1,i) = sim1
-            amdq(1,i) = fluxdiff
+            amdq(1,i) = fwave(1,1,i)
             apdq(1,i) = 0.d0
         else if (sim1 .ge. 0.d0 .and. si .gt. 0.d0) then
             ! right-going
             s(1,i) = si
             amdq(1,i) = 0.d0
-            apdq(1,i) = fluxdiff
+            apdq(1,i) = fwave(1,1,i)
         else if (sim1 .lt. 0.d0 .and. si .gt. 0.d0) then
             ! transonic rarefaction
             ! entropy fix:  (perhaps doesn't work for all cases!!!)
@@ -72,14 +71,14 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
             ! transonic shock
             s(1,i) = 0.5d0*(sim1 + si)
             if (s(1,i) .lt. 0.d0) then
-                amdq(1,i) = fluxdiff
+                amdq(1,i) = fwave(1,1,i)
                 apdq(1,i) = 0.d0
             else if (s(1,i) .gt. 0.d0) then
                 amdq(1,i) = 0.d0
-                apdq(1,i) = fluxdiff
+                apdq(1,i) = fwave(1,1,i)
             else
-                amdq(1,i) = 0.5d0 * fluxdiff
-                apdq(1,i) = 0.5d0 * fluxdiff
+                amdq(1,i) = 0.5d0 * fwave(1,1,i)
+                apdq(1,i) = 0.5d0 * fwave(1,1,i)
             endif
         endif
 

--- a/src/rp1_traffic_vc_tracer.f90
+++ b/src/rp1_traffic_vc_tracer.f90
@@ -21,7 +21,7 @@
 ! of the Riemann solver API.
 
 subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
-               ql,qr,auxl,auxr,wave,s,amdq,apdq)
+               ql,qr,auxl,auxr,fwave,s,amdq,apdq)
     implicit none
     ! Inputs
     integer, intent(in) :: maxm, num_eqn, num_waves, num_aux, num_ghost, num_cells
@@ -29,42 +29,41 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
     double precision, intent(in), dimension(num_aux, 1-num_ghost:maxm+num_ghost) :: auxl,auxr
     ! Outputs
     double precision, intent(out) :: s(num_waves,1-num_ghost:num_cells+num_ghost)
-    double precision, intent(out) :: wave(num_eqn,num_waves,1-num_ghost:num_cells+num_ghost)
+    double precision, intent(out) :: fwave(num_eqn,num_waves,1-num_ghost:num_cells+num_ghost)
     double precision, intent(out), dimension(num_eqn, 1-num_ghost:maxm+num_ghost) :: amdq,apdq
     ! Locals
-    double precision :: fim1, fi, sim1, si, f0, fluxdiff
+    double precision :: fim1, fi, sim1, si, f0
     integer :: i
 
     do i = 2-num_ghost, num_cells+num_ghost
         ! Compute the wave, speeds, and flux difference
 
-        ! compute flux in each cell and flux difference:
-        fim1 = auxr(1,i-1)*qr(1,i-1)*(1.d0 - qr(1,i-1))
-        fi   = auxl(1,i  )*ql(1,i  )*(1.d0 - ql(1,i  ))
-        fluxdiff = fi - fim1
-        wave(1,1,i) = ql(1,i) - qr(1,i-1)
-        wave(2,1,i) = 0.d0
-        wave(1,2,i) = 0.d0
-        wave(2,2,i) = ql(2,i) - qr(2,i-1)
-
         ! compute characteristic speed in each cell:
         sim1 = auxr(1,i-1)*(1.d0 - 2.d0*qr(1,i-1))
         si   = auxl(1,i  )*(1.d0 - 2.d0*ql(1,i  ))
-
         s(2,i) = auxl(1,i) * (1.d0 - ql(1,i))
-        apdq(2,i) = s(2,i) * wave(2,2,i)
+
+        ! compute flux in each cell and flux difference:
+        fim1 = auxr(1,i-1)*qr(1,i-1)*(1.d0 - qr(1,i-1))
+        fi   = auxl(1,i  )*ql(1,i  )*(1.d0 - ql(1,i  ))
+        fwave(1,1,i) = fi - fim1
+        fwave(2,1,i) = 0.d0
+        fwave(1,2,i) = 0.d0
+        fwave(2,2,i) = s(2,i)*(ql(2,i) - qr(2,i-1))
+
+        apdq(2,i) = fwave(2,2,i)
         amdq(2,i) = 0.d0 ! Traffic always moves right
 
         if (sim1 .lt. 0.d0 .and. si .le. 0.d0) then
             ! left-going
             s(1,i) = sim1
-            amdq(1,i) = fluxdiff
+            amdq(1,i) = fwave(1,1,i)
             apdq(1,i) = 0.d0
         else if (sim1 .ge. 0.d0 .and. si .gt. 0.d0) then
             ! right-going
             s(1,i) = si
             amdq(1,i) = 0.d0
-            apdq(1,i) = fluxdiff
+            apdq(1,i) = fwave(1,1,i)
         else if (sim1 .lt. 0.d0 .and. si .gt. 0.d0) then
             ! transonic rarefaction
             s(1,i) = 0.5d0*(sim1 + si)
@@ -73,7 +72,7 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
             ! This assumes the flux in the transonic case should
             ! correspond to q=0.5 on the side with the smaller umax value.
             f0 = dmin1(auxr(1,i-1),auxl(1,i))*0.25d0
-            ! split fluxdiff between amdq and apdq:
+            ! split fwave between amdq and apdq:
             amdq(1,i) = f0 - fim1
             apdq(1,i) = fi - f0
 
@@ -81,14 +80,14 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
             ! transonic shock
             s(1,i) = 0.5d0*(sim1 + si)
             if (s(1,i) .lt. 0.d0) then 
-                amdq(1,i) = fluxdiff
+                amdq(1,i) = fwave(1,1,i)
                 apdq(1,i) = 0.d0
             else if (s(1,i) .gt. 0.d0) then 
                 amdq(1,i) = 0.d0
-                apdq(1,i) = fluxdiff
+                apdq(1,i) = fwave(1,1,i)
             else
-                amdq(1,i) = 0.5d0 * fluxdiff 
-                apdq(1,i) = 0.5d0 * fluxdiff
+                amdq(1,i) = 0.5d0 * fwave(1,1,i)
+                apdq(1,i) = 0.5d0 * fwave(1,1,i)
             endif
         endif
 


### PR DESCRIPTION
Third time's a charm!

@rjleveque pointed out that my modifications to the variable-speed traffic solvers in #119 were not all correct.  This changes those solvers back to using f-waves while still including the minor bugfixes.

There is a small glitch with these solvers that seems to affect a single cell near the sonic point of a rarefaction and does not go away on refinement of the mesh.  This is perhaps expected (based on experience with Burgers) for the first-order algorithm, but not for the second-order algorithms.  Our best guess after some discussion is that since the wave speed is ~1.e-16 there, in the f-wave approach the wave nearly vanishes, which causes the limiter to essentially impose the first-order method near that point.  This glitch does go away if one uses the higher-order SharpClaw algorithms.