### PR TITLE
Quadratic stress-strain relation in Python elasticity solver

### DIFF
--- a/src/nonlinear_elasticity_1D_py.py
+++ b/src/nonlinear_elasticity_1D_py.py
@@ -20,7 +20,7 @@ Two stress-strain relations are included.  The default is
 
 ..  math:: \sigma(\epsilon,K) = \exp(K(x) \epsilon) - 1
 
-By setting problem_data['stress relation'] = 'quadratic' one can use instead
+By setting problem_data['stress_relation'] = 'quadratic' one can use instead
 
 ..  math:: \sigma(\epsilon,K_1,K_2) = K_1 \epsilon + K_2 \epsilon^2
 
@@ -101,7 +101,7 @@ def nonlinear_elasticity_1D(q_l, q_r, aux_l, aux_r, problem_data):
 
 def sigma(q, aux, problem_data):
     r"""Stress-strain relation."""
-    stress_relation = problem_data.get('stress relation', 'exponential')
+    stress_relation = problem_data.get('stress_relation', 'exponential')
     if stress_relation == 'exponential':
         return np.exp(aux[K,:]*q[strain,:])
     elif stress_relation == 'quadratic':
@@ -110,7 +110,7 @@ def sigma(q, aux, problem_data):
 
 def sigmap(q, aux, problem_data):
     r"""Derivative of stress-strain relation w.r.t. strain."""
-    stress_relation = problem_data.get('stress relation', 'exponential')
+    stress_relation = problem_data.get('stress_relation', 'exponential')
     if stress_relation == 'exponential':
         return aux[K,:]*np.exp(aux[K,:]*q[strain,:])
     elif stress_relation == 'quadratic':

--- a/src/nonlinear_elasticity_1D_py.py
+++ b/src/nonlinear_elasticity_1D_py.py
@@ -4,12 +4,12 @@ r"""
 F-wave Riemann solver for nonlinear elasticity in heterogeneous media
 
 .. math:: q_t + f(q,x)_x = 0
-  
-where 
 
-.. math:: 
+where
+
+.. math::
     q(x,t) = \left [ \begin{array}{c} \epsilon(x,t) \\ \rho(x) u(x,t) \end{array} \right ]
-  
+
 and the flux vector is
 
 .. math::
@@ -31,24 +31,30 @@ from __future__ import absolute_import
 import numpy as np
 from six.moves import range
 
-def nonlinear_elasticity_1D(q_l,q_r,aux_l,aux_r,problem_data):
+strain = 0
+momentum = 1
+density = 0
+K = 1
+K1 = 1
+K2 = 2
+
+
+def nonlinear_elasticity_1D(q_l, q_r, aux_l, aux_r, problem_data):
     r"""
     1d nonlinear elasticity riemann solver
-    
+
     *aux* is expected to contain -
      - aux[0,i] - density in cell i
      - aux[1,i] - bulk modulus in cell i
      - aux[2,i] - K2 (needed for quadratic stress relation only)
-    
+
     See :ref:`pyclaw_rp` for more details.
-    
-    :Version: 1.0 (2010-11-06)
     """
-    
+
     num_eqn = 2
     num_waves = 2
     # Convenience
-    num_rp = np.size(q_l,1)
+    num_rp = np.size(q_l, 1)
 
     # Set up arrays for return values
     fwave = np.empty( (num_eqn, num_waves, num_rp) )
@@ -56,33 +62,19 @@ def nonlinear_elasticity_1D(q_l,q_r,aux_l,aux_r,problem_data):
     amdq = np.empty( (num_eqn, num_rp) )
     apdq = np.empty( (num_eqn, num_rp) )
 
-    strain = 0
-    momentum = 1
-    density = 0
-    K = 1
-    K1 = 1
-    K2 = 2
-    
-    stress_relation = problem_data.get('stress relation','exponential')
-    if stress_relation == 'exponential':
-        sigma_l = np.exp(aux_l[K,:]*q_l[strain,:])
-        sigma_r = np.exp(aux_r[K,:]*q_r[strain,:])
-        bulk_l  = aux_l[K,:]*np.exp(aux_l[K,:]*q_l[strain,:])
-        bulk_r  = aux_r[K,:]*np.exp(aux_r[K,:]*q_r[strain,:])
-    elif stress_relation == 'quadratic':
-        sigma_l = aux_l[K1,:]*q_l[strain,:] + aux_l[K2,:]*q_l[strain,:]**2
-        sigma_r = aux_r[K1,:]*q_r[strain,:] + aux_r[K2,:]*q_r[strain,:]**2
-        bulk_l  = aux_l[K1,:] + 2*aux_l[K2,:]*q_l[strain,:]
-        bulk_r  = aux_r[K1,:] + 2*aux_r[K2,:]*q_r[strain,:]
+    sigma_l = sigma(q_l, aux_l, problem_data)
+    sigma_r = sigma(q_r, aux_r, problem_data)
+    bulk_l = sigmap(q_l, aux_l, problem_data)
+    bulk_r = sigmap(q_r, aux_r, problem_data)
 
-    #Linearized bulk modulus, sound speed, and impedance:
-    cl = np.sqrt(bulk_l/aux_l[0,:])
-    cr = np.sqrt(bulk_r/aux_r[0,:])
-    zl = cl*aux_l[0,:]
-    zr = cr*aux_r[0,:]
+    # Linearized bulk modulus, sound speed, and impedance:
+    cl = np.sqrt(bulk_l/aux_l[density,:])
+    cr = np.sqrt(bulk_r/aux_r[density,:])
+    zl = cl*aux_l[density,:]
+    zr = cr*aux_r[density,:]
 
-    #Jumps:
-    du   = q_r[1,:]/aux_r[0,:]-q_l[1,:]/aux_l[0,:]
+    # Jumps:
+    du = q_r[momentum,:]/aux_r[density,:]-q_l[momentum,:]/aux_l[density,:]
     dsig = sigma_r - sigma_l
 
     b1 = - (zr*du + dsig) / (zr+zl)
@@ -93,15 +85,33 @@ def nonlinear_elasticity_1D(q_l,q_r,aux_l,aux_r,problem_data):
     fwave[0,0,:] = b1
     fwave[1,0,:] = b1 * zl
     s[0,:] = -cl
-        
+
     # 2-Wave
     fwave[0,1,:] = b2
     fwave[1,1,:] = b2 * (-zr)
     s[1,:] = cr
-    
+
     # Compute the left going and right going fluctuations
     for m in range(num_eqn):
         amdq[m,:] = fwave[m,0,:]
         apdq[m,:] = fwave[m,1,:]
-    
+
     return fwave, s, amdq, apdq
+
+
+def sigma(q, aux, problem_data):
+    r"""Stress-strain relation."""
+    stress_relation = problem_data.get('stress relation', 'exponential')
+    if stress_relation == 'exponential':
+        return np.exp(aux[K,:]*q[strain,:])
+    elif stress_relation == 'quadratic':
+        return aux[K1,:]*q[strain,:] + aux[K2,:]*q[strain,:]**2
+
+
+def sigmap(q, aux, problem_data):
+    r"""Derivative of stress-strain relation w.r.t. strain."""
+    stress_relation = problem_data.get('stress relation', 'exponential')
+    if stress_relation == 'exponential':
+        return aux[K,:]*np.exp(aux[K,:]*q[strain,:])
+    elif stress_relation == 'quadratic':
+        return aux[K1,:] + 2*aux[K2,:]*q[strain,:]


### PR DESCRIPTION
This adds an option to use a quadratic stress-strain relation in the Python version (only) of the nonlinear elasticity solver.  Previously the only relation available was exponential, which is still the default.  I'm using the quadratic relation for a chapter in the Riemann solvers book.

The choice of which relation to use is controlled by setting `state.problem_data['stress relation']` to either `exponential` (default) or `quadratic`.

The solver could be adapted to other relations without modifying this file by just overriding `sigma()` and `sigmap()`.