### PR TITLE
Avoid artificially small CFL numbers in traffic_vc solver.

### DIFF
--- a/src/rp1_traffic_vc.f90
+++ b/src/rp1_traffic_vc.f90
@@ -51,7 +51,7 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         if (q_r .ne. q_l) then
             s(1,i) = (f_r-f_l)/(q_r - q_l)
         else
-            s(1,i) = 0.d0
+            s(1,i) = 0.5d0*(s_l + s_r) ! Avoid artificially small CFL number
         endif
 
         if ((f_l .ge. 0.25d0*v_r) .and. (s_r .gt. 0.d0)) then

--- a/src/rp1_traffic_vc_tracer.f90
+++ b/src/rp1_traffic_vc_tracer.f90
@@ -65,7 +65,7 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         if (q_r .ne. q_l) then
             s(1,i) = (f_r-f_l)/(q_r - q_l)
         else
-            s(1,i) = 0.d0
+            s(1,i) = 0.5d0*(s_l + s_r)
         endif
 
         ! Find Godunov flux in order to determine fluctuations


### PR DESCRIPTION
For piecewise constant initial data with certain special jumps,
the previous code led to an artificially small estimate of the
CFL number (and consequently, an excessively large initial step size).
This change still avoids division by zero and also avoids the
aforementioned behavior.