### PR TITLE
Use simple average of wavespeeds for 2nd-order term in traffic solvers.

### DIFF
--- a/src/rp1_traffic_vc.f90
+++ b/src/rp1_traffic_vc.f90
@@ -46,13 +46,10 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         f_l = v_l*q_l*(1.d0 - q_l)
         f_r = v_r*q_r*(1.d0 - q_r)
 
-        wave(1,1,i) = q_r - q_l ! Trying this even though it's not right
-
-        if (q_r .ne. q_l) then
-            s(1,i) = (f_r-f_l)/(q_r - q_l)
-        else
-            s(1,i) = 0.5d0*(s_l + s_r) ! Avoid artificially small CFL number
-        endif
+        ! This seems to work well even though there can be
+        ! a stationary jump in q.
+        wave(1,1,i) = q_r - q_l
+        s(1,i) = 0.5d0*(s_l + s_r)
 
         if ((f_l .ge. 0.25d0*v_r) .and. (s_r .gt. 0.d0)) then
             ! left-going shock, right-going rarefaction

--- a/src/rp1_traffic_vc_tracer.f90
+++ b/src/rp1_traffic_vc_tracer.f90
@@ -61,12 +61,7 @@ subroutine rp1(maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells, &
         apdq(2,i) = wave(2,2,i)
         amdq(2,i) = 0.d0 ! Traffic always moves right
 
-        ! Use Rankine-Hugoniot speed for q-wave
-        if (q_r .ne. q_l) then
-            s(1,i) = (f_r-f_l)/(q_r - q_l)
-        else
-            s(1,i) = 0.5d0*(s_l + s_r)
-        endif
+        s(1,i) = 0.5d0*(s_l + s_r)
 
         ! Find Godunov flux in order to determine fluctuations
         if ((f_l .ge. 0.25d0*v_r) .and. (s_r .gt. 0.d0)) then


### PR DESCRIPTION
This is the same as what is done in rp1_burgers.f90.