### PR TITLE
Added vectorized Riemann solvers for the single-layer shallow water equations

### DIFF
--- a/src/geoclaw_riemann_utils_vec.f90
+++ b/src/geoclaw_riemann_utils_vec.f90
@@ -1,0 +1,698 @@
+! This code has been adapted for vectorization. 
+! For more details on how to use it, see the Makefile of the chile2010 example.
+
+!-----------------------------------------------------------------------
+      subroutine riemann_aug_JCP(maxiter,meqn,mwaves,hL,hR,huL,huR, &
+        hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g,rho, &
+        sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33)
+      !dir$ attributes forceinline :: riemann_aug_JCP
+      !dir$ attributes vector: uniform(maxiter,meqn,mwaves,drytol,g,rho) :: riemann_aug_JCP
+
+      ! solve shallow water equations given single left and right states
+      ! This solver is described in J. Comput. Phys. (6): 3089-3113, March 2008
+      ! Augmented Riemann Solvers for the Shallow Equations with Steady States and Inundation
+
+      ! To use the original solver call with maxiter=1.
+
+      ! This solver allows iteration when maxiter > 1. The iteration seems to help with
+      ! instabilities that arise (with any solver) as flow becomes transcritical over variable topo
+      ! due to loss of hyperbolicity.
+
+      implicit none
+
+      !input
+      integer meqn,mwaves,maxiter
+      !double precision fw(meqn,mwaves)
+      !double precision sw(mwaves)
+      double precision sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33
+      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,sE1,sE2
+      double precision hvL,hvR,vL,vR,pL,pR
+      double precision drytol,g,rho
+
+
+      !local
+      integer m,mw,k,iter
+      double precision A(3,3)
+      double precision r(3,3)
+      double precision lambda(3)
+      double precision del(3)
+      double precision beta(3)
+
+      double precision delh,delhu,delphi,delb,delnorm
+      double precision rare1st,rare2st,sdelta,raremin,raremax
+      double precision criticaltol,convergencetol,raretol
+      double precision criticaltol_2, hustar_interface
+      double precision s1s2bar,s1s2tilde,hbar,hLstar,hRstar,hustar
+      double precision huRstar,huLstar,uRstar,uLstar,hstarHLL
+      double precision deldelh,deldelphi,delP
+      double precision s1m,s2m,hm
+      double precision det1,det2,det3,determinant
+
+      logical rare1,rare2,rarecorrector,rarecorrectortest,sonic
+      
+      ! used to pre-compute square roots
+      double precision sqrt_ghL, sqrt_ghR, sqrt_ghm
+
+      !determine del vectors
+      delh = hR-hL
+      delhu = huR-huL
+      delphi = phiR-phiL
+      delb = bR-bL
+      delP = pR - pL
+      delnorm = delh**2 + delphi**2
+
+      !DIR$ FORCEINLINE
+      call riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2, &
+                                               1,drytol,g)
+
+      ! pre-compute square roots:
+      sqrt_ghL = sqrt(g*hL)
+      sqrt_ghR = sqrt(g*hR)
+      sqrt_ghm = sqrt(g*hm)
+
+      lambda(1)= min(sE1,s2m) !Modified Einfeldt speed
+      lambda(3)= max(sE2,s1m) !Modified Eindfeldt speed
+      sE1=lambda(1)
+      sE2=lambda(3)
+      lambda(2) = 0.d0  ! ### Fix to avoid uninitialized value in loop on mw -- Correct?? ###
+
+      
+      hstarHLL = max((huL-huR+sE2*hR-sE1*hL)/(sE2-sE1),0.d0) ! middle state in an HLL solve
+
+      !determine the middle entropy corrector wave------------------------
+      rarecorrectortest=.false.
+      rarecorrector=.false.
+      if (rarecorrectortest) then
+         sdelta=lambda(3)-lambda(1)
+         raremin = 0.5d0
+         raremax = 0.9d0
+         if (rare1.and.sE1*s1m.lt.0.d0) raremin=0.2d0
+         if (rare2.and.sE2*s2m.lt.0.d0) raremin=0.2d0
+         if (rare1.or.rare2) then
+            !see which rarefaction is larger
+            rare1st=3.d0*(sqrt_ghL-sqrt_ghm)
+            rare2st=3.d0*(sqrt_ghR-sqrt_ghm)
+            if (max(rare1st,rare2st).gt.raremin*sdelta.and. &
+              max(rare1st,rare2st).lt.raremax*sdelta) then
+                  rarecorrector=.true.
+               if (rare1st.gt.rare2st) then
+                  lambda(2)=s1m
+               elseif (rare2st.gt.rare1st) then
+                  lambda(2)=s2m
+               else
+                  lambda(2)=0.5d0*(s1m+s2m)
+               endif
+            endif
+         endif
+         if (hstarHLL.lt.min(hL,hR)/5.d0) rarecorrector=.false.
+      endif
+
+!     ## Is this correct 2-wave when rarecorrector == .true. ??
+      do mw=1,mwaves
+         r(1,mw)=1.d0
+         r(2,mw)=lambda(mw)
+         r(3,mw)=(lambda(mw))**2
+      enddo
+      if (.not.rarecorrector) then
+         lambda(2) = 0.5d0*(lambda(1)+lambda(3))
+         !lambda(2) = max(min(0.5d0*(s1m+s2m),sE2),sE1)
+         r(1,2)=0.d0
+         r(2,2)=0.d0
+         r(3,2)=1.d0
+      endif
+      !---------------------------------------------------
+
+
+      !determine the steady state wave -------------------
+      !criticaltol = 1.d-6
+      ! MODIFIED:
+      criticaltol = max(drytol*g, 1d-6)
+      criticaltol_2 = sqrt(criticaltol)
+      deldelh = -delb
+      deldelphi = -0.5d0 * (hR + hL) * (g * delb + delp / rho)
+
+      !determine a few quanitites needed for steady state wave if iterated
+      hLstar=hL
+      hRstar=hR
+      uLstar=uL
+      uRstar=uR
+      huLstar=uLstar*hLstar
+      huRstar=uRstar*hRstar
+
+      !iterate to better determine the steady state wave
+      convergencetol=1.d-6
+!      do iter=1,maxiter  ! since maxiter=1, no loop needed!
+         !determine steady state wave (this will be subtracted from the delta vectors)
+         if (min(hLstar,hRstar).lt.drytol.and.rarecorrector) then
+            rarecorrector=.false.
+            hLstar=hL
+            hRstar=hR
+            uLstar=uL
+            uRstar=uR
+            huLstar=uLstar*hLstar
+            huRstar=uRstar*hRstar
+            lambda(2) = 0.5d0*(lambda(1)+lambda(3))
+            !lambda(2) = max(min(0.5d0*(s1m+s2m),sE2),sE1)
+            r(1,2)=0.d0
+            r(2,2)=0.d0
+            r(3,2)=1.d0
+         endif
+
+         hbar =  max(0.5d0*(hLstar+hRstar),0.d0)
+         s1s2bar = 0.25d0*(uLstar+uRstar)**2 - g*hbar
+         s1s2tilde= max(0.d0,uLstar*uRstar) - g*hbar
+
+         !find if sonic problem
+         ! MODIFIED from 5.3.1 version
+         sonic = .false.
+         if (abs(s1s2bar) <= criticaltol) then
+            sonic = .true.
+         else if (s1s2bar*s1s2tilde <= criticaltol**2) then
+            sonic = .true.
+         else if (s1s2bar*sE1*sE2 <= criticaltol**2) then
+            sonic = .true.
+         else if (min(abs(sE1),abs(sE2)) < criticaltol_2) then
+            sonic = .true.
+         else if (sE1 <  criticaltol_2 .and. s1m > -criticaltol_2) then
+            sonic = .true.
+         else if (sE2 > -criticaltol_2 .and. s2m <  criticaltol_2) then
+            sonic = .true.
+         else if ((uL+sqrt_ghL)*(uR+sqrt_ghR) < 0.d0) then
+            sonic = .true.
+         else if ((uL- sqrt_ghL)*(uR- sqrt_ghR) < 0.d0) then
+            sonic = .true.
+         end if
+
+         !find jump in h, deldelh
+         if (sonic) then
+            deldelh =  -delb
+         else
+            deldelh = delb*g*hbar/s1s2bar
+         endif
+         !find bounds in case of critical state resonance, or negative states
+         if (sE1.lt.-criticaltol.and.sE2.gt.criticaltol) then
+            deldelh = min(deldelh,hstarHLL*(sE2-sE1)/sE2)
+            deldelh = max(deldelh,hstarHLL*(sE2-sE1)/sE1)
+         elseif (sE1.ge.criticaltol) then
+            deldelh = min(deldelh,hstarHLL*(sE2-sE1)/sE1)
+            deldelh = max(deldelh,-hL)
+         elseif (sE2.le.-criticaltol) then
+            deldelh = min(deldelh,hR)
+            deldelh = max(deldelh,hstarHLL*(sE2-sE1)/sE2)
+         endif
+
+         !find jump in phi, deldelphi
+         if (sonic) then
+            deldelphi = -g*hbar*delb
+         else
+            deldelphi = -delb*g*hbar*s1s2tilde/s1s2bar
+         endif
+         !find bounds in case of critical state resonance, or negative states
+         deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
+         deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
+         deldelphi = deldelphi - hbar * delp / rho
+
+         del(1)=delh-deldelh
+         del(2)=delhu
+         del(3)=delphi-deldelphi
+
+         !Determine determinant of eigenvector matrix========
+         det1=r(1,1)*(r(2,2)*r(3,3)-r(2,3)*r(3,2))
+         det2=r(1,2)*(r(2,1)*r(3,3)-r(2,3)*r(3,1))
+         det3=r(1,3)*(r(2,1)*r(3,2)-r(2,2)*r(3,1))
+         determinant=det1-det2+det3
+
+         !solve for beta(k) using Cramers Rule=================
+         do k=1,3
+            do mw=1,3
+                  A(1,mw)=r(1,mw)
+                  A(2,mw)=r(2,mw)
+                  A(3,mw)=r(3,mw)
+            enddo
+            A(1,k)=del(1)
+            A(2,k)=del(2)
+            A(3,k)=del(3)
+            det1=A(1,1)*(A(2,2)*A(3,3)-A(2,3)*A(3,2))
+            det2=A(1,2)*(A(2,1)*A(3,3)-A(2,3)*A(3,1))
+            det3=A(1,3)*(A(2,1)*A(3,2)-A(2,2)*A(3,1))
+            beta(k)=(det1-det2+det3)/determinant
+         enddo
+
+         !exit if things aren't changing -> removed to allow vectorization!
+         !if (abs(del(1)**2+del(3)**2-delnorm).lt.convergencetol) exit
+         delnorm = del(1)**2+del(3)**2
+         !find new states qLstar and qRstar on either side of interface
+         hLstar=hL
+         hRstar=hR
+         uLstar=uL
+         uRstar=uR
+         huLstar=uLstar*hLstar
+         huRstar=uRstar*hRstar
+         do mw=1,mwaves
+            if (lambda(mw).lt.0.d0) then
+               hLstar= hLstar + beta(mw)*r(1,mw)
+               huLstar= huLstar + beta(mw)*r(2,mw)
+            endif
+         enddo
+         do mw=mwaves,1,-1
+            if (lambda(mw).gt.0.d0) then
+               hRstar= hRstar - beta(mw)*r(1,mw)
+               huRstar= huRstar - beta(mw)*r(2,mw)
+            endif
+         enddo
+
+         if (hLstar.gt.drytol) then
+            uLstar=huLstar/hLstar
+         else
+            hLstar=max(hLstar,0.d0)
+            uLstar=0.d0
+         endif
+         if (hRstar.gt.drytol) then
+            uRstar=huRstar/hRstar
+         else
+            hRstar=max(hRstar,0.d0)
+            uRstar=0.d0
+         endif
+
+  !    enddo ! end iteration on Riemann problem  ! since maxiter=1, no loop needed!
+
+!       do mw=1,mwaves
+!          sw(mw)=lambda(mw)
+!          fw(1,mw)=beta(mw)*r(2,mw)
+!          fw(2,mw)=beta(mw)*r(3,mw)
+!          fw(3,mw)=beta(mw)*r(2,mw)
+!       enddo
+      sw1 = lambda(1)
+      sw2 = lambda(2)
+      sw3 = lambda(3)
+      !mw=1
+      fw11 = beta(1)*r(2,1)
+      fw21 = beta(1)*r(3,1)
+      fw31 = beta(1)*r(2,1)
+      !mw=2
+      fw12 = beta(2)*r(2,2)
+      fw22 = beta(2)*r(3,2)
+      fw32 = beta(2)*r(2,2)
+      !mw=3
+      fw13 = beta(3)*r(2,3)
+      fw23 = beta(3)*r(3,3)
+      fw33 = beta(3)*r(2,3)
+
+      !find transverse components (ie huv jumps).
+      ! MODIFIED from 5.3.1 version
+!       fw(3,1)=fw(3,1)*vL
+!       fw(3,3)=fw(3,3)*vR
+!       fw(3,2)= 0.d0
+      fw31=fw31*vL
+      fw33=fw33*vR
+      fw32=0.d0
+ 
+!       hustar_interface = huL + fw(1,1)   ! = huR - fw(1,3)
+!       if (hustar_interface <= 0.0d0) then
+!           fw(3,1) = fw(3,1) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+!         else
+!           fw(3,3) = fw(3,3) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+!       end if
+      hustar_interface = huL + fw11   ! = huR - fw(1,3)
+      if (hustar_interface <= 0.0d0) then
+          fw31 = fw31 + (hR*uR*vR - hL*uL*vL - fw31- fw33)
+        else
+          fw33 = fw33 + (hR*uR*vR - hL*uL*vL - fw31- fw33)
+      end if
+
+
+      return
+
+      end !subroutine riemann_aug_JCP-------------------------------------------------
+
+
+!-----------------------------------------------------------------------
+      subroutine riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR, &
+         hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g, &
+         rho,sw,fw)
+
+      ! solve shallow water equations given single left and right states
+      ! steady state wave is subtracted from delta [q,f]^T before decomposition
+
+      implicit none
+
+      !input
+      integer meqn,mwaves,maxiter
+
+      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,sE1,sE2
+      double precision vL,vR,hvL,hvR,pL,pR
+      double precision drytol,g,rho
+
+      !local
+      integer iter
+
+      logical sonic
+
+      double precision delh,delhu,delphi,delb,delhdecomp,delphidecomp
+      double precision s1s2bar,s1s2tilde,hbar,hLstar,hRstar,hustar
+      double precision uRstar,uLstar,hstarHLL
+      double precision deldelh,deldelphi,delP
+      double precision alpha1,alpha2,beta1,beta2,delalpha1,delalpha2
+      double precision criticaltol,convergencetol
+      double precision sL,sR
+      double precision uhat,chat,sRoe1,sRoe2
+
+      double precision sw(mwaves)
+      double precision fw(meqn,mwaves)
+
+      !determine del vectors
+      delh = hR-hL
+      delhu = huR-huL
+      delphi = phiR-phiL
+      delb = bR-bL
+      delP = pR - pL
+
+      convergencetol= 1.d-16
+      criticaltol = 1.d-99
+
+      deldelh = -delb
+      deldelphi = -0.5d0 * (hR + hL) * (g * delb + delP / rho)
+
+!     !if no source term, skip determining steady state wave
+      if (abs(delb).gt.0.d0) then
+!
+         !determine a few quanitites needed for steady state wave if iterated
+         hLstar=hL
+         hRstar=hR
+         uLstar=uL
+         uRstar=uR
+         hstarHLL = max((huL-huR+sE2*hR-sE1*hL)/(sE2-sE1),0.d0) ! middle state in an HLL solve
+
+         alpha1=0.d0
+         alpha2=0.d0
+
+!        !iterate to better determine Riemann problem
+         !do iter=1,maxiter ! since maxiter=1, this loop is not neecessary!
+
+            !determine steady state wave (this will be subtracted from the delta vectors)
+            hbar =  max(0.5d0*(hLstar+hRstar),0.d0)
+            s1s2bar = 0.25d0*(uLstar+uRstar)**2 - g*hbar
+            s1s2tilde= max(0.d0,uLstar*uRstar) - g*hbar
+
+
+            !find if sonic problem
+            sonic=.false.
+            if (abs(s1s2bar).le.criticaltol) sonic=.true.
+            if (s1s2bar*s1s2tilde.le.criticaltol) sonic=.true.
+            if (s1s2bar*sE1*sE2.le.criticaltol) sonic = .true.
+            if (min(abs(sE1),abs(sE2)).lt.criticaltol) sonic=.true.
+
+            !find jump in h, deldelh
+            if (sonic) then
+               deldelh =  -delb
+            else
+               deldelh = delb*g*hbar/s1s2bar
+            endif
+!           !bounds in case of critical state resonance, or negative states
+            if (sE1.lt.-criticaltol.and.sE2.gt.criticaltol) then
+               deldelh = min(deldelh,hstarHLL*(sE2-sE1)/sE2)
+               deldelh = max(deldelh,hstarHLL*(sE2-sE1)/sE1)
+            elseif (sE1.ge.criticaltol) then
+               deldelh = min(deldelh,hstarHLL*(sE2-sE1)/sE1)
+               deldelh = max(deldelh,-hL)
+            elseif (sE2.le.-criticaltol) then
+               deldelh = min(deldelh,hR)
+               deldelh = max(deldelh,hstarHLL*(sE2-sE1)/sE2)
+            endif
+
+            !find jump in phi, deldelphi
+            if (sonic) then
+               deldelphi = -g*hbar*delb
+            else
+               deldelphi = -delb*g*hbar*s1s2tilde/s1s2bar
+            endif
+!           !bounds in case of critical state resonance, or negative states
+            deldelphi=min(deldelphi,g*max(-hLstar*delb,-hRstar*delb))
+            deldelphi=max(deldelphi,g*min(-hLstar*delb,-hRstar*delb))
+
+!---------determine fwaves ------------------------------------------
+
+!           !first decomposition
+            delhdecomp = delh-deldelh
+            delalpha1 = (sE2*delhdecomp - delhu)/(sE2-sE1)-alpha1
+            alpha1 = alpha1 + delalpha1
+            delalpha2 = (delhu - sE1*delhdecomp)/(sE2-sE1)-alpha2
+            alpha2 = alpha2 + delalpha2
+
+            !second decomposition
+            delphidecomp = delphi - deldelphi
+            beta1 = (sE2*delhu - delphidecomp)/(sE2-sE1)
+            beta2 = (delphidecomp - sE1*delhu)/(sE2-sE1)
+
+            ! no exits! -> vectorization
+!             if ((delalpha2**2+delalpha1**2).lt.convergencetol**2) then
+!                exit
+!             endif
+!
+            if (sE2.gt.0.d0.and.sE1.lt.0.d0) then
+               hLstar=hL+alpha1
+               hRstar=hR-alpha2
+!               hustar=huL+alpha1*sE1
+               hustar = huL + beta1
+            elseif (sE1.ge.0.d0) then
+               hLstar=hL
+               hustar=huL
+               hRstar=hR - alpha1 - alpha2
+            elseif (sE2.le.0.d0) then
+               hRstar=hR
+               hustar=huR
+               hLstar=hL + alpha1 + alpha2
+            endif
+!
+            if (hLstar.gt.drytol) then
+               uLstar=hustar/hLstar
+            else
+               hLstar=max(hLstar,0.d0)
+               uLstar=0.d0
+            endif
+!
+            if (hRstar.gt.drytol) then
+               uRstar=hustar/hRstar
+            else
+               hRstar=max(hRstar,0.d0)
+               uRstar=0.d0
+            endif
+
+         !enddo ! since maxiter=1, this loop is not neecessary!
+      endif
+
+      delhdecomp = delh - deldelh
+      delphidecomp = delphi - deldelphi
+
+      !first decomposition
+      alpha1 = (sE2*delhdecomp - delhu)/(sE2-sE1)
+      alpha2 = (delhu - sE1*delhdecomp)/(sE2-sE1)
+
+      !second decomposition
+      beta1 = (sE2*delhu - delphidecomp)/(sE2-sE1)
+      beta2 = (delphidecomp - sE1*delhu)/(sE2-sE1)
+
+      ! 1st nonlinear wave
+      fw(1,1) = alpha1*sE1
+      fw(2,1) = beta1*sE1
+      fw(3,1) = fw(1,1)*vL
+      ! 2nd nonlinear wave
+      fw(1,3) = alpha2*sE2
+      fw(2,3) = beta2*sE2
+      fw(3,3) = fw(1,3)*vR
+      ! advection of transverse wave
+      fw(1,2) = 0.d0
+      fw(2,2) = 0.d0
+      fw(3,2) = hR*uR*vR - hL*uL*vL -fw(3,1)-fw(3,3)
+      !speeds
+      sw(1)=sE1
+      sw(2)=0.5d0*(sE1+sE2)
+      sw(3)=sE2
+
+      return
+
+      end subroutine !-------------------------------------------------
+
+
+!-----------------------------------------------------------------------
+      subroutine riemann_fwave(meqn,mwaves,hL,hR,huL,huR,hvL,hvR, &
+                 bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,s1,s2,drytol,g,rho, &
+                 sw,fw)
+
+      ! solve shallow water equations given single left and right states
+      ! solution has two waves.
+      ! flux - source is decomposed.
+
+      implicit none
+
+      !input
+      integer meqn,mwaves
+
+      double precision hL,hR,huL,huR,bL,bR,uL,uR,phiL,phiR,s1,s2
+      double precision hvL,hvR,vL,vR,pL,pR
+      double precision drytol,g,rho
+
+      double precision sw(mwaves)
+      double precision fw(meqn,mwaves)
+
+      !local
+      double precision delh,delhu,delphi,delb,delhdecomp,delphidecomp
+      double precision deldelh,deldelphi,delP
+      double precision beta1,beta2
+
+
+      !determine del vectors
+      delh = hR-hL
+      delhu = huR-huL
+      delphi = phiR-phiL
+      delb = bR-bL
+      delP = pR - pL
+
+      deldelphi = -0.5d0 * (hR + hL) * (g * delb + delP / rho)
+      delphidecomp = delphi - deldelphi
+
+      !flux decomposition
+      beta1 = (s2*delhu - delphidecomp)/(s2-s1)
+      beta2 = (delphidecomp - s1*delhu)/(s2-s1)
+
+      sw(1)=s1
+      sw(2)=0.5d0*(s1+s2)
+      sw(3)=s2
+      ! 1st nonlinear wave
+      fw(1,1) = beta1
+      fw(2,1) = beta1*s1
+      fw(3,1) = beta1*vL
+      ! 2nd nonlinear wave
+      fw(1,3) = beta2
+      fw(2,3) = beta2*s2
+      fw(3,3) = beta2*vR
+      ! advection of transverse wave
+      fw(1,2) = 0.d0
+      fw(2,2) = 0.d0
+      fw(3,2) = hR*uR*vR - hL*uL*vL -fw(3,1)-fw(3,3)
+      return
+
+      end !subroutine -------------------------------------------------
+
+
+
+
+
+!=============================================================================
+      subroutine riemanntype(hL,hR,uL,uR,hm,s1m,s2m,rare1,rare2, &
+                  maxiter,drytol,g)
+
+      !determine the Riemann structure (wave-type in each family)
+
+
+      implicit none
+
+      !input
+      double precision hL,hR,uL,uR,drytol,g
+      integer maxiter
+
+      !output
+      double precision s1m,s2m
+      logical rare1,rare2
+
+      !local
+      double precision hm,u1m,u2m,um,delu
+      double precision h_max,h_min,h0,F_max,F_min,dfdh,F0,slope,gL,gR
+      integer iter
+      double precision sqrt_ghL, sqrt_ghR
+
+
+
+      !Test for Riemann structure
+
+      h_min=min(hR,hL)
+      h_max=max(hR,hL)
+      delu=uR-uL
+      
+      ! pre-compute square roots:
+      sqrt_ghL = sqrt(g*hL)
+      sqrt_ghR = sqrt(g*hR)
+
+      if (h_min.le.drytol) then
+         hm=0.d0
+         um=0.d0
+         s1m=uR+uL-2.d0*sqrt_ghR+2.d0*sqrt_ghL
+         s2m=uR+uL-2.d0*sqrt_ghR+2.d0*sqrt_ghL
+         if (hL.le.0.d0) then
+            rare2=.true.
+            rare1=.false.
+         else
+            rare1=.true.
+            rare2=.false.
+         endif
+
+      else
+         F_min= delu+2.d0*(sqrt(g*h_min)-sqrt(g*h_max))
+         F_max= delu + &
+              (h_max-h_min)*(sqrt(.5d0*g*(h_max+h_min)/(h_max*h_min))) 
+
+         if (F_min.gt.0.d0) then !2-rarefactions
+
+            hm=(1.d0/(16.d0*g))* &
+                    max(0.d0,-delu+2.d0*(sqrt_ghL+sqrt_ghR))**2
+            um=sign(1.d0,hm)*(uL+2.d0*(sqrt_ghL-sqrt(g*hm)))
+
+            s1m=uL+2.d0*sqrt_ghL-3.d0*sqrt(g*hm)
+            s2m=uR-2.d0*sqrt_ghR+3.d0*sqrt(g*hm)
+
+            rare1=.true.
+            rare2=.true.
+
+         elseif (F_max.le.0.d0) then !2 shocks
+
+            !root finding using a Newton iteration on sqrt(h)===
+            h0=h_max
+            do iter=1,maxiter
+               gL=sqrt(.5d0*g*(1/h0 + 1/hL))
+               gR=sqrt(.5d0*g*(1/h0 + 1/hR))
+               F0=delu+(h0-hL)*gL + (h0-hR)*gR
+               dfdh=gL-g*(h0-hL)/(4.d0*(h0**2)*gL)+ &
+                        gR-g*(h0-hR)/(4.d0*(h0**2)*gR)
+               slope=2.d0*sqrt(h0)*dfdh
+               h0=(sqrt(h0)-F0/slope)**2
+            enddo
+               hm=h0
+               u1m=uL-(hm-hL)*sqrt((.5d0*g)*(1/hm + 1/hL))
+               u2m=uR+(hm-hR)*sqrt((.5d0*g)*(1/hm + 1/hR))
+               um=.5d0*(u1m+u2m)
+
+               s1m=u1m-sqrt(g*hm)
+               s2m=u2m+sqrt(g*hm)
+               rare1=.false.
+               rare2=.false.
+
+         else !one shock one rarefaction
+            h0=h_min
+
+            do iter=1,maxiter
+               F0=delu + 2.d0*(sqrt(g*h0)-sqrt(g*h_max)) &
+                       + (h0-h_min)*sqrt(.5d0*g*(1/h0+1/h_min))
+               slope=(F_max-F0)/(h_max-h_min)
+               h0=h0-F0/slope
+            enddo
+
+            hm=h0
+            if (hL.gt.hR) then
+               um=uL+2.d0*sqrt_ghL-2.d0*sqrt(g*hm)
+               s1m=uL+2.d0*sqrt_ghL-3.d0*sqrt(g*hm)
+               s2m=uL+2.d0*sqrt_ghL-sqrt(g*hm)
+               rare1=.true.
+               rare2=.false.
+            else
+               s2m=uR-2.d0*sqrt_ghR+3.d0*sqrt(g*hm)
+               s1m=uR-2.d0*sqrt_ghR+sqrt(g*hm)
+               um=uR-2.d0*sqrt_ghR+2.d0*sqrt(g*hm)
+               rare2=.true.
+               rare1=.false.
+            endif
+         endif
+      endif
+
+      return
+
+      end ! subroutine riemanntype----------------------------------------------------------------

--- a/src/rpn2_geoclaw_vec.f90
+++ b/src/rpn2_geoclaw_vec.f90
@@ -1,0 +1,403 @@
+! This code has been adapted for vectorization. 
+! For more details on how to use it, see the Makefile of the chile2010 example.
+
+!======================================================================
+       subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx, &
+                      ql,qr,auxl,auxr,fwave,s,amdq,apdq)
+!======================================================================
+!
+! Solves normal Riemann problems for the 2D SHALLOW WATER equations
+!     with topography:
+!     #        h_t + (hu)_x + (hv)_y = 0                           #
+!     #        (hu)_t + (hu^2 + 0.5gh^2)_x + (huv)_y = -ghb_x      #
+!     #        (hv)_t + (huv)_x + (hv^2 + 0.5gh^2)_y = -ghb_y      #
+
+! On input, ql contains the state vector at the left edge of each cell
+!     qr contains the state vector at the right edge of each cell
+!
+! This data is along a slice in the x-direction if ixy=1
+!     or the y-direction if ixy=2.
+
+!  Note that the i'th Riemann problem has left state qr(i-1,:)
+!     and right state ql(i,:)
+!  From the basic clawpack routines, this routine is called with
+!     ql = qr
+!
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                           !
+!      # This Riemann solver is for the shallow water equations.            !
+!                                                                           !
+!       It allows the user to easily select a Riemann solver in             !
+!       riemannsolvers_geo.f. this routine initializes all the variables    !
+!       for the shallow water equations, accounting for wet dry boundary    !
+!       dry cells, wave speeds etc.                                         !
+!                                                                           !
+!           David George, Vancouver WA, Feb. 2009                           !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance, rho
+      use geoclaw_module, only: earth_radius, deg2rad
+      use amr_module, only: mcapa
+
+      use storm_module, only: pressure_forcing, pressure_index
+      use statistics
+
+      implicit none
+
+      !input
+      integer maxm,meqn,maux,mwaves,mbc,mx,ixy
+
+      double precision  fwave(1-mbc:maxm+mbc, meqn, mwaves)
+      double precision  s(1-mbc:maxm+mbc, mwaves)
+      double precision  ql(1-mbc:maxm+mbc, meqn)
+      double precision  qr(1-mbc:maxm+mbc, meqn)
+      double precision  apdq(1-mbc:maxm+mbc,meqn)
+      double precision  amdq(1-mbc:maxm+mbc,meqn)
+      double precision  auxl(1-mbc:maxm+mbc,maux)
+      double precision  auxr(1-mbc:maxm+mbc,maux)
+
+      !local only
+      integer m,i,mw,maxiter,mu,nv
+      double precision wall(3)
+      !double precision fw(3,3)
+      !double precision sw(3)
+      double precision fw11, fw12, fw13, fw21, fw22, fw23, fw31, fw32, fw33
+      double precision sw1, sw2, sw3
+
+      double precision hR,hL,huR,huL,hvR,hvL,pL,pR
+      double precision bR,bL
+
+      double precision tw,dxdc
+      
+      double precision sqrt_ghL, sqrt_ghR
+
+      logical rare1,rare2
+      
+      interface
+        subroutine solve_rpn2(hL, hR, huL, huR, hvL, hvR, bL, bR, pL, pR,sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33) 
+            real(kind=8), intent(inout) :: sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33
+            real(kind=8), intent(inout) :: hL, hR, huL, huR, hvL, hvR, bL, bR, pL, pR
+        end subroutine
+      end interface
+
+      ! In case there is no pressure forcing
+      pL = 0.d0
+      pR = 0.d0
+      
+      !set normal direction
+      if (ixy.eq.1) then
+         mu=2
+         nv=3
+      else
+         mu=3
+         nv=2
+      endif
+
+      !loop through Riemann problems at each grid cell
+#if defined(_OPENMP)
+      !$OMP SIMD PRIVATE(hL,hR,huL,huR,hvL,hvR,bL,bR,pL,pR, &
+      !$OMP& fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33,sw1,sw2,sw3)
+#endif
+      do i=2-mbc,mx+mbc
+
+         !Riemann problem variables
+         hL = qr(i-1,1) 
+         hR = ql(i,1) 
+         huL = qr(i-1,mu) 
+         huR = ql(i,mu) 
+         bL = auxr(i-1,1)
+         bR = auxl(i,1)
+         pL = 0.d0
+         pR = 0.d0
+         if (pressure_forcing) then
+             pL = auxr(i-1,pressure_index)
+             pR = auxl(i, pressure_index)
+         end if
+
+         hvL=qr(i-1,nv) 
+         hvR=ql(i,nv)
+         
+         sw1 = 0.0d0
+         sw2 = 0.0d0
+         sw3 = 0.0d0
+         fw11 = 0.0d0
+         fw21 = 0.0d0
+         fw31 = 0.0d0
+         fw12 = 0.0d0
+         fw22 = 0.0d0
+         fw32 = 0.0d0
+         fw13 = 0.0d0
+         fw23 = 0.0d0
+         fw33 = 0.0d0   
+         
+         !DIR$ FORCEINLINE
+         call solve_rpn(hL, hR, huL, huR, hvL, hvR, bL, bR, pL, pR, sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33) 
+        
+
+         s(i,1) = sw1
+         s(i,2) = sw2
+         s(i,3) = sw3
+         ! mw=1
+         fwave(i, 1,1) = fw11
+         fwave(i,mu,1) = fw21
+         fwave(i,nv,1) = fw31
+         ! mw=2
+         fwave(i,1, 2) = fw12
+         fwave(i,mu,2) = fw22
+         fwave(i,nv,2) = fw32
+         ! mw=3
+         fwave(i,1, 3) = fw13
+         fwave(i,mu,3) = fw23
+         fwave(i,nv,3) = fw33
+         
+      enddo
+
+
+!==========Capacity for mapping from latitude longitude to physical space====
+      if (mcapa > 0) then
+          if (ixy == 1) then
+              dxdc = earth_radius*deg2rad
+              !DIR$ SIMD
+              do i=2-mbc,mx+mbc
+                  do mw=1,3
+                      s(i,mw) = dxdc * s(i,mw)
+                      fwave(i,1,mw) = dxdc*fwave(i,1,mw)
+                      fwave(i,2,mw) = dxdc*fwave(i,2,mw)
+                      fwave(i,3,mw) = dxdc*fwave(i,3,mw)
+                  enddo
+              enddo
+          else
+              !DIR$ SIMD
+              do i=2-mbc,mx+mbc
+                  dxdc=earth_radius*cos(auxl(i,3))*deg2rad
+                  do mw=1,3
+                      s(i,mw) = dxdc * s(i,mw)
+                      fwave(i,1,mw)=dxdc*fwave(i,1,mw)
+                      fwave(i,2,mw)=dxdc*fwave(i,2,mw)
+                      fwave(i,3,mw)=dxdc*fwave(i,3,mw)
+                  enddo
+              enddo
+          endif
+      endif
+
+!===============================================================================
+
+      do i=1-mbc,mx+mbc
+          do m=1,3
+              amdq(i,m) = 0.d0
+          enddo
+      enddo
+
+
+      do i=1-mbc,mx+mbc
+          do m=1,3
+              apdq(i,m) = 0.d0
+         enddo
+      enddo 
+
+      !============= compute fluctuations=============================================
+
+      !DIR$ SIMD
+      do i=2-mbc,mx+mbc
+           do  mw=1,3
+              if (s(i,mw) < 0.d0) then
+                  amdq(i,1:3) = amdq(i,1:3) + fwave(i,1:3,mw)
+              else if (s(i,mw) > 0.d0) then
+                  apdq(i,1:3)  = apdq(i,1:3) + fwave(i,1:3,mw)
+              else
+                  amdq(i,1:3) = amdq(i,1:3) + 0.5d0 * fwave(i,1:3,mw)
+                  apdq(i,1:3) = apdq(i,1:3) + 0.5d0 * fwave(i,1:3,mw)
+              endif
+          enddo
+      enddo
+
+      return
+      end subroutine
+      
+      
+      
+subroutine solve_rpn(hL, hR, huL, huR, hvL, hvR, bL, bR, pL, pR, sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33)      
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance, rho
+      use geoclaw_module, only: earth_radius, deg2rad
+      use amr_module, only: mcapa
+
+      use storm_module, only: pressure_forcing, pressure_index
+      use statistics
+
+      implicit none
+
+      !input
+      double precision hL, hR, huL, huR, hvL, hvR, bL, bR, pL, pR
+      
+      !output
+      !double precision sw(3), fw(3,3)
+      double precision sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33
+
+      !local only
+      integer m,i,mw,maxiter
+      double precision wall1, wall2, wall3
+      double precision uR,uL,vR,vL,phiR,phiL
+      double precision sL,sR,sRoe1,sRoe2,sE1,sE2,uhat,chat
+      double precision s1m,s2m
+      double precision hstar,hstartest,hstarHLL,sLtest,sRtest
+      double precision tw,dxdc      
+      double precision sqrt_ghL, sqrt_ghR
+      logical rare1,rare2
+         
+         ! For completely dry states, do not skip problem (hinders
+         ! vectorization), but rather solve artificial 0-valued problem.
+         if (hL < drytol .and. hR < drytol) then
+            hL = 0
+            hR = 0
+         endif
+
+         !check for wet/dry boundary
+         if (hR.gt.drytol) then
+            uR=huR/hR
+            vR=hvR/hR
+            phiR = 0.5d0*g*hR**2 + huR**2/hR
+         else
+            hR = 0.d0
+            huR = 0.d0
+            hvR = 0.d0
+            uR = 0.d0
+            vR = 0.d0
+            phiR = 0.d0
+         endif
+
+         if (hL.gt.drytol) then
+            uL=huL/hL
+            vL=hvL/hL
+            phiL = 0.5d0*g*hL**2 + huL**2/hL
+         else
+            hL=0.d0
+            huL=0.d0
+            hvL=0.d0
+            uL=0.d0
+            vL=0.d0
+            phiL = 0.d0
+         endif
+
+         wall1 = 1.d0
+         wall2 = 1.d0
+         wall3 = 1.d0
+         if (hR.le.drytol) then
+            !DIR$ FORCEINLINE
+            call riemanntype(hL,hL,uL,-uL,hstar,s1m,s2m, &
+                                       rare1,rare2,1,drytol,g)
+            hstartest=max(hL,hstar)
+            if (hstartest+bL.lt.bR) then !right state should become ghost values that mirror left for wall problem
+               !bR=hstartest+bL
+               wall2=0.d0
+               wall3=0.d0
+               hR=hL
+               huR=-huL
+               bR=bL
+               phiR=phiL
+               uR=-uL
+               vR=vL
+            elseif (hL+bL.lt.bR) then
+               bR=hL+bL
+            endif
+         elseif (hL.le.drytol) then ! right surface is lower than left topo
+            !DIR$ FORCEINLINE
+            call riemanntype(hR,hR,-uR,uR,hstar,s1m,s2m, &
+                                       rare1,rare2,1,drytol,g)
+            hstartest=max(hR,hstar)
+            if (hstartest+bR.lt.bL) then  !left state should become ghost values that mirror right
+              !bL=hstartest+bR
+               wall1=0.d0
+               wall2=0.d0
+               hL=hR
+               huL=-huR
+               bL=bR
+               phiL=phiR
+               uL=-uR
+               vL=vR
+            elseif (hR+bR.lt.bL) then
+               bL=hR+bR
+            endif
+         endif
+         
+         ! pre-compute square roots
+         sqrt_ghL = sqrt(g*hL)
+         sqrt_ghR = sqrt(g*hR)
+
+         !determine wave speeds
+         sL=uL-sqrt_ghL ! 1 wave speed of left state
+         sR=uR+sqrt_ghR ! 2 wave speed of right state
+
+         uhat=(sqrt_ghL*uL + sqrt_ghR*uR)/(sqrt_ghR+sqrt_ghL) ! Roe average
+         chat=sqrt(g*0.5d0*(hR+hL)) ! Roe average
+         sRoe1=uhat-chat ! Roe wave speed 1 wave
+         sRoe2=uhat+chat ! Roe wave speed 2 wave
+
+         sE1 = min(sL,sRoe1) ! Eindfeldt speed 1 wave
+         sE2 = max(sR,sRoe2) ! Eindfeldt speed 2 wave
+
+         !--------------------end initializing...finally----------
+         !solve Riemann problem.
+
+         maxiter = 1
+
+         !DIR$ FORCEINLINE
+         call riemann_aug_JCP(maxiter,3,3,hL,hR,huL, &
+             huR,hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2, &
+             drytol,g,rho,sw1,sw2,sw3,fw11,fw12,fw13,fw21,fw22,fw23,fw31,fw32,fw33)
+
+!          call riemann_ssqfwave(maxiter,meqn,mwaves,hL,hR,huL,huR,
+!      &     hvL,hvR,bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g,
+!      &     rho,sw,fw)
+
+!          call riemann_fwave(meqn,mwaves,hL,hR,huL,huR,hvL,hvR,
+!      &      bL,bR,uL,uR,vL,vR,phiL,phiR,pL,pR,sE1,sE2,drytol,g,rho,sw,
+!      &      fw)
+
+
+
+          ! For completely dry states, waves should be always zero!
+          ! (these problems could have been skipped, but to allow 
+          ! vectorization they weren't)
+          if (hL < drytol .and. hR < drytol) then
+             sw1 = 0.0d0
+             sw2 = 0.0d0
+             sw3 = 0.0d0
+             fw11 = 0.0d0
+             fw21 = 0.0d0
+             fw31 = 0.0d0
+             fw12 = 0.0d0
+             fw22 = 0.0d0
+             fw32 = 0.0d0
+             fw13 = 0.0d0
+             fw23 = 0.0d0
+             fw33 = 0.0d0            
+          endif
+
+
+          !eliminate ghost fluxes for wall
+!           do mw=1,3
+!              sw(mw)=sw(mw)*wall(mw)
+!  
+!                 fw(1,mw)=fw(1,mw)*wall(mw) 
+!                 fw(2,mw)=fw(2,mw)*wall(mw)
+!                 fw(3,mw)=fw(3,mw)*wall(mw)
+!           enddo
+
+            sw1 = sw1 * wall1
+            sw2 = sw2 * wall2
+            sw3 = sw3 * wall3
+            !mw=1
+            fw11 = fw11 * wall1
+            fw21 = fw21 * wall1
+            fw31 = fw31 * wall1
+            !mw=2
+            fw12 = fw12 * wall2
+            fw22 = fw22 * wall2
+            fw32 = fw32 * wall2
+            !mw=3
+            fw13 = fw13 * wall3
+            fw23 = fw23 * wall3
+            fw33 = fw33 * wall3
+
+end subroutine

--- a/src/rpt2_geoclaw_vec.f90
+++ b/src/rpt2_geoclaw_vec.f90
@@ -1,0 +1,211 @@
+! This code has been adapted for vectorization. 
+! For more details on how to use it, see the Makefile of the chile2010 example.
+
+! =====================================================
+subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx, &
+        ql,qr,aux1,aux2,aux3,asdq,bmasdq,bpasdq)
+    ! =====================================================
+    use geoclaw_module, only: g => grav, tol => dry_tolerance
+    use geoclaw_module, only: coordinate_system,earth_radius,deg2rad
+
+    implicit none
+    !
+    !     # Riemann solver in the transverse direction using an einfeldt
+    !     Jacobian.
+
+    !-----------------------last modified 1/10/05----------------------
+
+    integer, parameter :: DP = kind(1.d0)
+
+    real(kind=DP) :: ql(1-mbc:maxm+mbc, meqn)
+    real(kind=DP) :: qr(1-mbc:maxm+mbc, meqn)
+    real(kind=DP) :: asdq(1-mbc:maxm+mbc,meqn)
+    real(kind=DP) :: bmasdq(1-mbc:maxm+mbc,meqn)
+    real(kind=DP) :: bpasdq(1-mbc:maxm+mbc,meqn)
+    real(kind=DP) :: aux1(1-mbc:maxm+mbc,maux)
+    real(kind=DP) :: aux2(1-mbc:maxm+mbc,maux)
+    real(kind=DP) :: aux3(1-mbc:maxm+mbc,maux)
+    real(kind=DP) :: s(3)
+    real(kind=DP) :: r(3,3)
+    real(kind=DP) :: beta(3)
+    real(kind=DP) :: abs_tol
+    real(kind=DP) :: hl,hr,hul,hur,hvl,hvr,vl,vr,ul,ur,bl,br
+    real(kind=DP) :: uhat,vhat,hhat,roe1,roe3,s1,s2,s3,s1l,s3r
+    real(kind=DP) :: delf1,delf2,delf3
+    real(kind=DP) :: dxdcm,dxdcp,topo1,topo3,eta
+
+    integer :: ixy,maxm,meqn,maux,mwaves,mbc,mx,imp
+    integer :: i,m,mw,mu,mv
+  
+
+    abs_tol=tol
+
+    if (ixy.eq.1) then
+        mu = 2
+        mv = 3
+    else
+        mu = 3
+        mv = 2
+    endif
+
+#if defined(_OPENMP)
+    !$OMP SIMD PRIVATE(hl,hr,hul,hur,hvl,hvr,s1,s2,s3, &
+    !$OMP& dxdcm,dxdcp,delf1,delf2,delf3,topo1,topo3,beta,s,r)
+#endif
+    do i=2-mbc,mx+mbc
+        hl=qr(i-1,1) 
+        hr=ql(i,1) 
+        hul=qr(i-1,mu) 
+        hur=ql(i,mu) 
+        hvl=qr(i-1,mv) 
+        hvr=ql(i,mv)
+
+        do mw=1,mwaves
+            s(mw)=0.d0
+            beta(mw)=0.d0
+            do m=1,meqn
+                r(mw,m)=0.d0
+            enddo
+        enddo
+        
+        ! check and see if cell that transverse waves are going in is high and dry
+        if (imp.eq.1) then
+            eta = qr(i-1,1)  + aux2(i-1,1)
+            topo1 = aux1(i-1,1)
+            topo3 = aux3(i-1,1)
+        else
+            eta = ql(i,1) + aux2(i,1)
+            topo1 = aux1(i,1)
+            topo3 = aux3(i,1)
+        endif
+
+        if (eta<max(topo1,topo3)) then
+            hl = 0.d0
+            hr = 0.d0
+        endif 
+
+        call solve_single_rpt(g, tol, hl, hul, hvl, hr, hur, hvr, s1, s2, s3)
+
+        s(1)=s1
+        s(2)=s2
+        s(3)=s3
+        !=======================Determine asdq decomposition (beta)============
+        delf1=asdq(i,1)
+        delf2=asdq(i,mu)
+        delf3=asdq(i,mv)
+
+        beta(1) = (s3*delf1/(s3-s1))-(delf3/(s3-s1))
+        beta(2) = -s2*delf1 + delf2
+        beta(3) = (delf3/(s3-s1))-(s1*delf1/(s3-s1))
+        !======================End =================================================
+
+        !=====================Set-up eigenvectors===================================
+        r(1,1) = 1.d0
+        r(1,2) = s2
+        r(1,3) = s1
+
+        r(2,1) = 0.d0
+        r(2,2) = 1.d0
+        r(2,3) = 0.d0
+
+        r(3,1) = 1.d0
+        r(3,2) = s2
+        r(3,3) = s3
+        !============================================================================
+        90      continue
+        !============= compute fluctuations==========================================
+
+        dxdcp = 1.d0
+        dxdcm = 1.d0
+
+        if (coordinate_system.eq.2) then
+            if (ixy.eq.2) then
+                dxdcp=(earth_radius*deg2rad)
+                dxdcm = dxdcp
+            else
+                if (imp.eq.1) then
+                    dxdcp = earth_radius*cos(aux3(i-1,3))*deg2rad
+                    dxdcm = earth_radius*cos(aux1(i-1,3))*deg2rad
+                else
+                    dxdcp = earth_radius*cos(aux3(i,3))*deg2rad
+                    dxdcm = earth_radius*cos(aux1(i,3))*deg2rad
+                endif
+            endif
+        endif
+
+        bmasdq(i,:)=0.0d0
+        bpasdq(i,:)=0.0d0
+        do mw=1,3
+            if (s(mw)<0.d0) then
+                bmasdq(i,1) =bmasdq(i,1) + dxdcm*s(mw)*beta(mw)*r(mw,1)
+                bmasdq(i,mu)=bmasdq(i,mu)+ dxdcm*s(mw)*beta(mw)*r(mw,2)
+                bmasdq(i,mv)=bmasdq(i,mv)+ dxdcm*s(mw)*beta(mw)*r(mw,3)
+            elseif (s(mw)>0.d0) then
+                bpasdq(i,1) =bpasdq(i,1) + dxdcp*s(mw)*beta(mw)*r(mw,1)
+                bpasdq(i,mu)=bpasdq(i,mu)+ dxdcp*s(mw)*beta(mw)*r(mw,2)
+                bpasdq(i,mv)=bpasdq(i,mv)+ dxdcp*s(mw)*beta(mw)*r(mw,3)
+            endif
+        enddo
+        !========================================================================
+    enddo
+    
+    return
+end subroutine 
+
+
+subroutine solve_single_rpt(g, tol, hl, hul, hvl, hr, hur, hvr, &
+        s1, s2, s3)
+    implicit none
+    integer, parameter :: DP = kind(1.d0)
+
+    !real(kind=DP), intent(inout) :: dxdcm, dxdcp
+    real(kind=DP), intent(in) :: g, tol, hul, hvl, hur, hvr
+    real(kind=DP), intent(out) :: s1, s2, s3
+    real(kind=DP), intent(inout) :: hl, hr 
+    real(kind=DP) :: ul, vl, ur, vr, roe1, roe3, s1l, s3r,uhat,vhat,hhat, &
+        sqhl, sqhr
+    !===========determine velocity from momentum===========================
+    if (hl<tol) then
+        hl=0.d0
+        ul=0.d0
+        vl=0.d0
+    else
+        ul=hul/hl
+        vl=hvl/hl
+    endif
+
+    if (hr<tol) then
+        hr=0.d0
+        ur=0.d0
+        vr=0.d0
+    else
+        ur=hur/hr
+        vr=hvr/hr
+    endif
+
+
+    if (hl <= tol .and. hr <= tol) then
+        s1 = 0.d0
+        s2 = 0.d0
+        s3 = 0.d0
+    else
+        !=====Determine some speeds necessary for the Jacobian=================
+        sqhr = sqrt(hr)
+        sqhl = sqrt(hl)
+    !---------------------------------------
+        vhat=(vr*sqhr)/(sqhr+sqhl) + (vl*sqhl)/(sqhr+sqhl)
+        uhat=(ur*sqhr)/(sqhr+sqhl) + (ul*sqhl)/(sqhr+sqhl)
+    !---------------------------------------
+        hhat=(hr+hl)*0.5d0
+    !---------------------------------------
+        roe1=vhat-sqrt(g*hhat)
+        roe3=vhat+sqrt(g*hhat)
+    !---------------------------------------
+        s1l=vl-sqrt(g*hl)
+        s3r=vr+sqrt(g*hr)
+
+        s1=min(roe1,s1l)
+        s3=max(roe3,s3r)
+        s2=0.5d0*(s1+s3)
+    endif
+end subroutine


### PR DESCRIPTION
These changes introduce new vectorized implementations for the single-layer shallow water equations (chile2010 example). The user can easily switch between the serial and the vectorized code: to use vectorization, one needs to define GEOCLAW_VEC=1 before compiling. More info in the chile2010 Makefile.