### PR TITLE
geoclaw solver must incorporate delP in deldelh

### DIFF
--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -187,6 +187,9 @@ c        !find bounds in case of critical state resonance, or negative states
             deldelh = max(deldelh,hstarHLL*(sE2-sE1)/sE2)
          endif
 
+c        ! adjust deldelh for well-balancing of atmospheric pressure difference 
+         deldelh = deldelh - delP/(rho*g)
+
 c        !find jump in phi, deldelphi
          if (sonic) then
             deldelphi = -g*hbar*delb


### PR DESCRIPTION
Since the augmented geoclaw solver includes delh as well as delphi, the jump in
atmospheric pressure must be used to modify this component as well when
doing a well-balanced Riemann solve.

@mandli:  @mjberger and I discovered that the incorporating atmospheric pressure into the well-balanced Riemann solver does not maintain the steady state in which B=0, u=v=0, and 
  h = -B - p/(rho*g), 
e.g. with a Gaussian hump for the atmospheric pressure p.  This should be an exact numerical steady state if h in each cell is set this way based on a static pressure prescribed in `aux(pressure_index,:,:)`.   We tracked this down to needing the modification proposed here.  

Note that in equation (44) of the [JCP paper](https://doi.org/10.1016/j.jcp.2007.10.027) by @dlgeorge,  the `delh` is modified by `delB` in addition to the necessary modification to `delphi`.  Similarly, `delP` now needs to modify `delh` in addition to the modification already implemented to `delphi`.

We tested this and it now preserves the steady state mentioned above.  It also gets rid of the big residual currents that showed up in the case when the initial surface is flat and the Gaussian static pressure leads to a steady state, which now looks good, and converges to u, v ~ 1e-6 as the transient moves out of the domain.  But still not exactly symmetric.

It would be good to test this in a storm surge case and see if still behaves well (better?).