### PR TITLE
Use 'cparam' instead of 'param' for the common block.

### DIFF
--- a/src/euler_roe_solver_mapgrid.f90
+++ b/src/euler_roe_solver_mapgrid.f90
@@ -8,10 +8,12 @@
     double precision :: gamma, gamma1
     integer :: m, p, mu, mv, ixy, i, j, k, info
 
-    common /param/ gamma, gamma1
+    common /cparam/ gamma, gamma1
 
 
     info = 0
+
+    gamma1 = gamma - 1.d0
 
 !     # These are used even in the mapped case, but ixy is
 !     # always set to 1;  rotation matrix rot does switches

--- a/src/rpn2_euler_mapgrid.f90
+++ b/src/rpn2_euler_mapgrid.f90
@@ -41,7 +41,7 @@ subroutine rpn2(ixy,maxm, meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,ap
     integer :: mcapa,locrot, locarea
     double precision :: rot(4), area
 
-    common /param/  gamma
+    common /cparam/  gamma
 
     data efix /.true./
 
@@ -157,7 +157,7 @@ subroutine rpn2(ixy,maxm, meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,ap
 
     integer :: m
 
-    common /param/ gamma
+    common /cparam/ gamma
 
     gamma1 = gamma - 1.d0
 

--- a/src/rpt2_euler_mapgrid.f90
+++ b/src/rpt2_euler_mapgrid.f90
@@ -66,7 +66,7 @@ subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,aux1,aux2,aux3,asdq,b
 
     logical :: in_rpt
 
-    common /param/  gamma
+    common /cparam/  gamma
 
     gamma1 = gamma - 1.d0
 


### PR DESCRIPTION
The value of gamma wasn't getting passed to the Riemann solver because the Python code assumes the common block is named `cparam` but in these solvers it was named `param`.  This is a particularly fragile part of PyClaw and any suggestions for making it more robust would be welcome.  In the meantime, this fixes this case and I couldn't find any other problems of this kind among all the existing Riemann solvers.