### PR TITLE
Install matplotlib on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sudo apt-get install -qq gfortran liblapack-pic
   # Print NumPy version that is already installed by Travis CI:
   - python -c "import numpy; print(numpy.__version__)"
+  - pip install matplotlib
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init


### PR DESCRIPTION
Because we use PyClaw for tests and PyClaw imports Visclaw imports matplotlib.