### PR TITLE
In 1D shallow water equations with tracer, tracer index should be 2 (not 3).

### DIFF
--- a/riemann/shallow_roe_tracer_1D_constants.py
+++ b/riemann/shallow_roe_tracer_1D_constants.py
@@ -4,4 +4,4 @@ num_eqn   = 3
 # Conserved quantities
 depth = 0
 momentum = 1
-tracer = 3
+tracer = 2


### PR DESCRIPTION
Thanks to Daria Bolbot for catching this bug.