### PR TITLE
Move adjoint riemann solvers

### DIFF
--- a/src/rpn2_geoclaw_adjoint_qwave.f90
+++ b/src/rpn2_geoclaw_adjoint_qwave.f90
@@ -1,0 +1,213 @@
+!======================================================================
+       subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx, &
+                       ql,qr,auxl,auxr,wave,s,amdq,apdq)
+!======================================================================
+!
+! Solves normal Riemann problems for the adjoint of the linearized
+! 2D shallow water equations with topography.
+! Uses q-waves, not f-waves, since the forward solve is in conservation
+! form using f-waves.
+!
+! The full nonlinear forward problem in the x-direction is:
+!     h_t + (hu)_x = 0
+!     (hu)_t + (h*u^2 + 0.5*g*h^2)_x = -g*h*B_x(x)
+! where h is the depth, hu the momentum, and B(x) the topography/bathymetry.
+!
+! The linearized forward problem is:
+!     eta_t + mom_x = 0
+!     mom_t + [g*h0(x) * eta]_x = 0
+! where (eta, mom) are the surface displacement eta and linearized momentum,
+! and h0(x) is the background depth (ocean at rest), so h0(x) = max(-B(x), 0).
+!
+! Note the forward problem is in conservation form q_t + (A(x)q)_x = 0, 
+! so the adjoint equation is non-conservative and has the form
+!     q_hat_t + A(x)^T q_hat_x = 0
+! with coefficient matrix is
+!     A(x)^T = [0  g*h0(x)]
+!              [1     0   ]
+!
+! We need to solve the adjoint backwards in time, but we convert this into
+! a problem going forward in time in order to apply GeoClaw, by solving
+!     q_hat_t - A(x)^T q_hat_x = 0.
+!
+! Hence the Riemann solver uses the eigenvalues/vectors of -A(x)^T, which are:
+!     lambda_1 = -c0,  r_1 = [+c0, 1]^T,
+!     lambda_2 = +c0,  r_2 = [-c0, 1]^T.
+!
+! If h0 < drytol on one side of the interface, then "solid wall" BCs
+! are used to find the single wave propagating into the ocean with mom=0 behind.
+!
+! On input, ql contains the state vector at the left edge of each cell
+!     qr contains the state vector at the right edge of each cell
+!
+! This data is along a slice in the x-direction if ixy=1
+!     or the y-direction if ixy=2.
+
+!  Note that the i'th Riemann problem has left state qr(i-1,:)
+!     and right state ql(i,:)
+!  From the basic clawpack routines, this routine is called with
+!     ql = qr
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                           !
+!      # This Riemann solver is for the shallow water adjoint               !
+!             equations. It is modified from rpn2_geoclaw.f.                !
+!                                                                           !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      use geoclaw_module, only: g => grav, drytol => dry_tolerance
+      use geoclaw_module, only: earth_radius, deg2rad
+      use amr_module, only: mcapa, use_fwaves
+
+      implicit none
+
+      !input
+      integer, intent(in) :: maxm,meqn,maux,mwaves,mbc,mx,ixy
+
+      real(kind=8), intent(in) ::  ql(meqn, 1-mbc:maxm+mbc)
+      real(kind=8), intent(in) ::  qr(meqn, 1-mbc:maxm+mbc)
+      real(kind=8), intent(in) ::  auxl(maux,1-mbc:maxm+mbc)
+      real(kind=8), intent(in) ::  auxr(maux,1-mbc:maxm+mbc)
+      real(kind=8), intent(out) ::  wave(meqn, mwaves, 1-mbc:maxm+mbc)
+      real(kind=8), intent(out) ::  s(mwaves, 1-mbc:maxm+mbc)
+      real(kind=8), intent(out) ::  apdq(meqn,1-mbc:maxm+mbc)
+      real(kind=8), intent(out) ::  amdq(meqn,1-mbc:maxm+mbc)
+
+      ! local 
+      integer :: m,i,mu,nv
+      real(kind=8) :: delta(2)
+      real(kind=8) :: h0R,h0L,huR,huL,etaR,etaL
+      real(kind=8) :: hR,hL,bR,bL,cL,cR,alf1,alf2,dxdc
+      logical dryL,dryR
+
+      if (mwaves .ne. 2) then
+         write(6,*) '*** Adjoint solver requires num_waves = 2'
+         stop
+         endif
+
+      if (use_fwaves) then
+         write(6,*) '*** Adjoint solver requires use_fwaves=False'
+         stop
+         endif
+
+      ! initialize for dry areas:
+      wave(:,:,:) = 0.d0
+      s(:,:) = 1.d0
+      amdq(:,:) = 0.d0
+      apdq(:,:) = 0.d0
+
+      !loop through Riemann problems at each grid cell
+      do i=2-mbc,mx+mbc
+
+         ! background depth based on topography:
+         bL = auxr(1,i-1)
+         bR = auxl(1,i)
+         h0L = max(-bL, 0.d0)
+         h0R = max(-bR, 0.d0)
+
+         !skip problem if in a completely dry area
+         if (h0L <= drytol .and. h0R <= drytol) then
+             cycle ! go to next i
+         endif
+         
+         !set normal direction
+         if (ixy.eq.1) then
+            mu=2
+            nv=3
+         else
+            mu=3
+            nv=2
+         endif
+
+        ! linearized eta:
+        hL = qr(1,i-1)
+        hR = ql(1,i)
+        etaL = hL + bL
+        etaR = hR + bR
+
+        ! linearized momenta:
+        huL = qr(mu,i-1)
+        huR = ql(mu,i)
+
+        ! wave speeds
+        cL = sqrt(g*h0L) ! 1 wave speed is -cL
+        cR = sqrt(g*h0R) ! 2 wave speed is +cR
+
+
+        ! Check for wet/dry boundary
+        if (hR <= drytol) then
+            ! set "ghost cell" values for zero momentum BC:
+            etaR = etaL
+            huR = -huL
+            dryR = .true.
+            cR = cL
+        else
+            dryR = .false.
+        endif
+
+        if (hL <= drytol) then
+            ! set "ghost cell" values for zero momentum BC:
+            etaL = etaR
+            huL = -huR
+            dryL = .true.
+            cL = cR
+        else
+            dryL = .false.
+        endif
+
+        
+        ! Roe average speeds 
+        ! More consistent with forward solver, but doesn't make much difference
+        !cL = sqrt(g*0.5d0*(h0L+h0R)) ! 1 wave speed is -cL
+        !cR = sqrt(g*0.5d0*(h0L+h0R)) ! 2 wave speed is +cR
+        
+        if ((cL<drytol) .and. (cR<drytol)) then
+            ! should not happen
+            write(6,*) '*** g,h0L,h0r: ',g,h0L,h0r
+            endif
+
+        !--------------------end initializing----------
+        ! solve Riemann problem.
+
+        ! q-wave splitting
+        delta(1) = etaR - etaL
+        delta(2) = huR - huL
+
+        alf1 = (delta(1) + cR*delta(2))/(cL + cR)
+        alf2 = (-delta(1) + cL*delta(2))/(cL + cR)
+
+        ! eliminate one wave if dry to either side:
+        if (dryL) alf1 = 0.d0
+        if (dryR) alf2 = 0.d0
+
+        ! Compute the waves.
+        wave(1,1,i) = cL*alf1
+        wave(mu,1,i) = alf1
+        wave(nv,1,i) = 0.d0
+        s(1,i) = -cL
+
+        wave(1,2,i) = -cR*alf2
+        wave(mu,2,i) = alf2
+        wave(nv,2,i) = 0.d0
+        s(2,i) = cR
+        
+!====== Adjust for mapping from latitude longitude to physical space====
+        if (mcapa.gt.0) then
+            if (ixy.eq.1) then
+               dxdc=(earth_radius*deg2rad)
+            else
+               dxdc=earth_radius*cos(auxl(3,i))*deg2rad
+            endif
+            s(1,i) = dxdc * s(1,i)
+            s(2,i) = dxdc * s(2,i)
+        endif
+
+        ! Fluctuations: 
+        ! 1-wave is always left-going, 2-wave is right-going
+        amdq(1:meqn,i) = s(1,i) * wave(1:meqn,1,i)
+        apdq(1:meqn,i) = s(2,i) * wave(1:meqn,2,i)
+
+      enddo
+
+      return
+      end subroutine rpn2

--- a/src/rpt2_geoclaw_adjoint_qwave.f90
+++ b/src/rpt2_geoclaw_adjoint_qwave.f90
@@ -1,0 +1,140 @@
+! =====================================================
+subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr, &
+                aux1,aux2,aux3,asdq,bmasdq,bpasdq)
+! =====================================================
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                           !
+!      # This Riemann solver is for the shallow water adjoint               !
+!             equations. It is similar to rpt2_vc_acoustics.f90
+!                                                                           !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!     # Split asdq into down-going flux bmasdq and up-going flux bpasdq.
+!     # imp=1  means  asdq=amdq,    imp=2 means asdq=apdq
+
+    use geoclaw_module, only: g => grav, drytol => dry_tolerance
+    use geoclaw_module, only: coordinate_system,earth_radius,deg2rad
+
+    implicit none
+
+    integer, intent(in) :: ixy,imp,maxm,meqn,mwaves,maux,mbc,mx
+    real(kind=8), intent(in) ::    ql(meqn, 1-mbc:maxm+mbc)
+    real(kind=8), intent(in) ::    qr(meqn, 1-mbc:maxm+mbc)
+    real(kind=8), intent(in) ::    asdq(meqn, 1-mbc:maxm+mbc)
+    real(kind=8), intent(in) ::   aux1(maux, 1-mbc:maxm+mbc)
+    real(kind=8), intent(in) ::   aux2(maux, 1-mbc:maxm+mbc)
+    real(kind=8), intent(in) ::   aux3(maux, 1-mbc:maxm+mbc)
+    real(kind=8), intent(out) :: bmasdq(meqn, 1-mbc:maxm+mbc)
+    real(kind=8), intent(out) :: bpasdq(meqn, 1-mbc:maxm+mbc)
+
+!   local:
+    integer :: i,mu,mv,i1
+    real(kind=8) :: h0D,h00,h0U,bD,b0,bU,c0,cU,cD,a1,a2,dxdcU,dxdcD,s1,s2
+
+!   # initialize for dry state cells:
+    bmasdq = 0.d0
+    bpasdq = 0.d0
+    
+    if (ixy == 1) then
+        mu = 2
+        mv = 3
+    else
+        mu = 3
+        mv = 2
+    endif
+
+    do i = 2-mbc, mx+mbc
+
+         if (maxval(abs(asdq(:,i))) == 0.d0) then
+            cycle  ! go to next i
+            endif
+    
+!        # imp is used to flag whether wave is going to left or right,
+!        # since material properties are different on the two sides
+    
+        if (imp == 1) then
+!            # asdq = amdq, moving to left
+            i1 = i-1
+        else
+!            # asdq = apdq, moving to right
+            i1 = i
+        endif
+        
+    
+!       # The flux difference asdq is split into downward moving part
+!       # traveling at speed -cD relative to the medium below and
+!       # an upward moving part traveling
+!       # at speed +cU relative to the medium above.
+   
+!       # Note that the sum of these parts does not give all of asdq
+!       # since there is also reflection at the interfaces which decreases
+!       # the flux.
+    
+!       # gravity wave speed in each row of cells:
+
+        ! background depth based on topography:
+        bD = aux1(1,i1)
+        b0 = aux2(1,i1)
+        bU = aux3(1,i1)
+        h0U = max(-bU, 0.d0)
+        h00 = max(-b0, 0.d0)
+        h0D = max(-bD, 0.d0)
+        cD = sqrt(g*h0D)
+        c0 = sqrt(g*h00)
+        cU = sqrt(g*h0U)
+
+        if (h00 < drytol) then
+            cycle  ! no waves in this cell
+            endif
+
+!       # transmitted part of down-going wave:
+        if (h0D < drytol) then
+            a1 = 0.d0  ! no transmitted wave
+        else
+            a1 = (asdq(1,i) + asdq(mv,i)*c0) / (c0 + cD)
+        endif
+
+!       # transmitted part of up-going wave:
+        if (h0U < drytol) then
+            a2 = 0.d0  ! no transmitted wave
+        else
+            a2 = (-asdq(1,i) + asdq(mv,i)*c0) / (c0 + cU)
+        endif
+        
+        !====== Adjust for mapping from latitude longitude to physical space====
+        if (coordinate_system.eq.2) then
+           if (ixy.eq.2) then
+               dxdcU=(earth_radius*deg2rad)
+               dxdcD = dxdcU
+           else
+               dxdcU = earth_radius*cos(aux3(3,i1))*deg2rad
+               dxdcD = earth_radius*cos(aux1(3,i1))*deg2rad
+           endif
+        else
+            dxdcU = 1.d0
+            dxdcD = 1.d0
+        endif
+
+    
+!       # The down-going flux difference bmasdq is the product  -cD * wave1
+!       # down-going eigenvector of -A(x)^T is r1 = [cD, 1]^T
+    
+        s1 = -cD * dxdcD  ! adjusted down-going wave speed
+        bmasdq(1,i) = s1 * a1*cD
+        bmasdq(mu,i) = 0.d0
+        bmasdq(mv,i) = s1 * a1
+    
+!       # The up-going flux difference bpasdq is the product  cU * wave2
+!       # up-going eigenvector of -A(x)^T is r2 = [-cU, 1]^T
+    
+        s2 = cU * dxdcU  ! adjusted up-going wave speed
+        bpasdq(1,i) = s2 * a2*(-cU)
+        bpasdq(mu,i) = 0.d0
+        bpasdq(mv,i) = s2 * a2
+    
+        enddo
+
+    return
+    end subroutine rpt2

--- a/src/rpt2_geoclaw_adjoint_qwave.f90
+++ b/src/rpt2_geoclaw_adjoint_qwave.f90
@@ -8,6 +8,8 @@ subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,ql,qr, &
 !                                                                           !
 !      # This Riemann solver is for the shallow water adjoint               !
 !             equations. It is similar to rpt2_vc_acoustics.f90
+!
+!      # See rpn2_geoclaw_adjoint_qwave.f90 for the equations and discussion!
 !                                                                           !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Moved two adjoint Riemann solvers for shallow water equations to this repository from geoclaw/src/2d/shallow, last updated in https://github.com/clawpack/geoclaw/commit/223ee2a22a4c69a5ca19dc073e6c3296170ccbda