### PR TITLE
fix rpn2_vc_acoustics codes to use auxr

### DIFF
--- a/src/rpn2_vc_acoustics.f90
+++ b/src/rpn2_vc_acoustics.f90
@@ -87,7 +87,7 @@ subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apd
         delta(2) = ql(mu,i) - qr(mu,i-1)
     !        # impedances:
         zi = auxl(1,i)*auxl(2,i)
-        zim = auxl(1,i-1)*auxl(2,i-1)
+        zim = auxr(1,i-1)*auxr(2,i-1)
 
         a1 = (-delta(1) + zi*delta(2)) / (zim + zi)
         a2 =  (delta(1) + zim*delta(2)) / (zim + zi)
@@ -98,7 +98,7 @@ subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apd
         wave(1,1,i) = -a1*zim
         wave(mu,1,i) = a1
         wave(mv,1,i) = 0.d0
-        s(1,i) = -auxl(2,i-1)
+        s(1,i) = -auxr(2,i-1)
     
         wave(1,2,i) = a2*zi
         wave(mu,2,i) = a2

--- a/src/rpn2_vc_acoustics_adjoint.f90
+++ b/src/rpn2_vc_acoustics_adjoint.f90
@@ -86,15 +86,15 @@ subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,fwave,s,amdq,ap
 
 !        # impedances:
         zi = auxl(1,i)*auxl(2,i)
-        zim = auxl(1,i-1)*auxl(2,i-1)
+        zim = auxr(1,i-1)*auxr(2,i-1)
 
 !       # sound speed
         ci = auxl(2,i)
-        cim = auxl(2,i-1)
+        cim = auxr(2,i-1)
 
 !       # density
         rhoi = auxl(1,i)
-        rhoim = auxl(1,i-1)
+        rhoim = auxr(1,i-1)
 
 !       # bulk modulus
         bulki = rhoi*ci**2


### PR DESCRIPTION
Need to use auxr(:,i-1) not auxl(:,i-1) in both forward and adjoint solvers.
Bug showed up in testing updated adjoint problem examples for paper:
bad ghost cell values propagate inwards.