### PR TITLE
Fix for problem with HLLE and near-dry states

### DIFF
--- a/src/rp1_shallow_hlle.f90
+++ b/src/rp1_shallow_hlle.f90
@@ -36,28 +36,39 @@ subroutine rp1(maxmx,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
         u_r = ql(2,i  ) / ql(1,i  )
         c_l = dsqrt(grav*h_l)
         c_r = dsqrt(grav*h_r)
-
-        ! Roe averages
-        hsqrt_l = dsqrt(qr(1,i-1))
-        hsqrt_r = dsqrt(ql(1,i))
-        h_hat = 0.5*(h_l + h_r)
-        u_hat = (hsqrt_l*u_l + hsqrt_r*u_r) / (hsqrt_l + hsqrt_r)
-        c_hat = dsqrt(grav*h_hat)
-
-        s1 = min(u_l - c_l, u_hat - c_hat)
-        s2 = max(u_r + c_r, u_hat + c_hat)
-
-        ! Middle state
-        h_m = (ql(2,i) - qr(2,i-1) - s2*h_r + s1*h_l) / (s1-s2)
-        hu_m = (ql(2,i)*(u_r-s2) - qr(2,i-1)*(u_l-s1) + 0.5*grav*(h_r**2-h_l**2)) / (s1-s2)
-
-        wave(1,1,i) = h_m - h_l
-        wave(2,1,i) = hu_m - qr(2,i-1)
-        s(1,i) = s1
+            
+        if (h_l<1.e-14 .AND. h_r<1.e-14) then
+            wave(1,1,i) =0.
+            wave(2,1,i) =0.
+            s(1,i) = 0.
     
-        wave(1,2,i) = h_r - h_m
-        wave(2,2,i) = ql(2,i) - hu_m
-        s(2,i) = s2
+            wave(1,2,i) = 0.
+            wave(2,2,i) = 0.
+            s(2,i) = 0.
+            
+        else
+            ! Roe averages
+            hsqrt_l = dsqrt(qr(1,i-1))
+            hsqrt_r = dsqrt(ql(1,i))
+            h_hat = 0.5*(h_l + h_r)
+            u_hat = (hsqrt_l*u_l + hsqrt_r*u_r) / (hsqrt_l + hsqrt_r)
+            c_hat = dsqrt(grav*h_hat)
+
+            s1 = min(u_l - c_l, u_hat - c_hat)
+            s2 = max(u_r + c_r, u_hat + c_hat)
+
+            ! Middle state
+            h_m = (ql(2,i) - qr(2,i-1) - s2*h_r + s1*h_l) / (s1-s2)
+            hu_m = (ql(2,i)*(u_r-s2) - qr(2,i-1)*(u_l-s1) + 0.5*grav*(h_r**2-h_l**2)) / (s1-s2)
+               
+            wave(1,1,i) = h_m - h_l
+            wave(2,1,i) = hu_m - qr(2,i-1)
+            s(1,i) = s1
+    
+            wave(1,2,i) = h_r - h_m
+            wave(2,2,i) = ql(2,i) - hu_m
+            s(2,i) = s2
+        end if
 
     end do 
 


### PR DESCRIPTION
When running a 1D dam-break simulation with a initial near-dry state, the HLLE solver gave a wrong solution. The following image corresponds to the output of hl=1, hr=1e-33, ul=ur=0, using the Classic solver with mx=4000 and order=1:
![Dry_state_HLLE](https://user-images.githubusercontent.com/29715468/115829049-1bd0e000-a3d4-11eb-8554-7f17103cc59e.png)
This seems to be caused by the denominator (s1-s2) getting close to zero while computing middle states. The proposed fix just sets the speeds and waves as zero whenever both hl and hr are smaller than a tolerance (1e-14). This is the output with the same initial values after applying the changes:
![Dry_state_HLLE_1](https://user-images.githubusercontent.com/29715468/115831411-2c368a00-a3d7-11eb-9b45-a7457b34ef97.png)
