### PR TITLE
typo fix in docs: eqn of state has pressure and energy

### DIFF
--- a/riemann/euler_1D_py.py
+++ b/riemann/euler_1D_py.py
@@ -25,7 +25,7 @@ energy and :math:`p` is the pressure.
 Unless otherwise noted, the ideal gas equation of state is used:
 
 .. math::
-    E = (\gamma - 1) \left (E - \frac{1}{2}\rho u^2 \right)
+    p = (\gamma - 1) \left (E - \frac{1}{2}\rho u^2 \right)
 """
 
 import numpy as np


### PR DESCRIPTION
Just a minor typo I noticed when preparing lectures: the equation of state needs to relate pressure to energy, not energy to itself