### PR TITLE
Remove the py_dep dependency from extension modules in riemann/meson.build

### DIFF
--- a/riemann/meson.build
+++ b/riemann/meson.build
@@ -149,7 +149,6 @@ foreach suffix, names: riemann_ptwise
       ext_name, [ext_srcs, f2py_srcs],
       incdir_f2py / 'fortranobject.c',
       include_directories: inc_np,
-      dependencies : py_dep,
       subdir: pkg_dir,
       install : true
     )
@@ -172,7 +171,6 @@ foreach suffix, names: riemann
       ext_name, [ext_srcs, f2py_srcs],
       incdir_f2py / 'fortranobject.c',
       include_directories: inc_np,
-      dependencies : py_dep,
       subdir: pkg_dir,
       install : true
     )
@@ -224,7 +222,6 @@ foreach name, sources: special_extensions
     ext_name, [ext_srcs, f2py_srcs],
     incdir_f2py / 'fortranobject.c',
     include_directories: inc_np,
-    dependencies : py_dep,
     subdir: pkg_dir,
     install : true
   )


### PR DESCRIPTION
This is only a minor cleanup, it doesn't change behavior. Adding the dependency isn't necessary since Meson 0.63:
https://mesonbuild.com/Release-notes-for-0-63-0.html#python-extension-modules-now-depend-on-the-python-library-by-default

Cleanup is the same as for `pyclaw` here: https://github.com/clawpack/pyclaw/pull/722