### PR TITLE
Add missing `-` from fluctuation loop

### DIFF
--- a/src/rpn2_shallow_bathymetry_fwave.f90
+++ b/src/rpn2_shallow_bathymetry_fwave.f90
@@ -127,7 +127,7 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
         ! Fluctuations - could probably rewrite this to be a masking operation
         ! instead...
         do k=1, num_waves
-            if (s(k, i) < 1.0e-14) then
+            if (s(k, i) < -1.0e-14) then
                 amdq(:, i) = amdq(:, i) + fwave(:, k, i)
             elseif (s(k, i) > 1.0e-14) then
                 apdq(:, i) = apdq(:, i) + fwave(:, k, i)


### PR DESCRIPTION
In the shallow water fwave solver the final loop over the waves is missing a negative sign.  As is the `if` statement was never reaching the case where the speed $s_k = 0$ and splitting the wave $\mathcal{Z_k}$ into both $\mathcal{A}^\pm \Delta Q$.