### PR TITLE
Compile RS for Euler with gravity at installation

### DIFF
--- a/riemann/__init__.py
+++ b/riemann/__init__.py
@@ -50,6 +50,7 @@ from . import vc_acoustics_3D_constants
 from . import euler_3D_constants
 from . import burgers_3D_constants
 from . import vc_advection_3D_constants
+from . import euler_mapgrid_3D
 
 
 try:
@@ -99,6 +100,7 @@ try:
     from . import euler_3D
     from . import burgers_3D
     from . import vc_advection_3D
+    from . import euler_mapgrid_3D
 except ImportError as e:
     import traceback
     print("********************************************************************")

--- a/riemann/meson.build
+++ b/riemann/meson.build
@@ -111,6 +111,7 @@ riemann_2D = [
 riemann_3D = [
   'vc_acoustics',
   'euler',
+  'euler_mapgrid'
   'burgers',
   'vc_advection',
 ]
@@ -226,3 +227,24 @@ foreach name, sources: special_extensions
     install : true
   )
 endforeach
+
+ext_name = 'mappedGrid'
+ext_srcs = [
+  srcdir / 'euler3d_mappedGrid.f90',
+]
+f2py_srcs = custom_target(
+  'f2py_mappedGrid',
+  command: [f2py, ext_name],
+  input: ext_srcs,
+  output: [ext_name + 'module.c', ext_name + '-f2pywrappers2.f90'],
+  build_by_default: true,
+)
+
+py.extension_module(
+  ext_name, [ext_srcs, f2py_srcs],
+  incdir_f2py / 'fortranobject.c',
+  include_directories: inc_np,
+  dependencies : py_dep,
+  subdir: pkg_dir,
+  install : true
+)

--- a/riemann/meson.build
+++ b/riemann/meson.build
@@ -111,7 +111,7 @@ riemann_2D = [
 riemann_3D = [
   'vc_acoustics',
   'euler',
-  'euler_mapgrid'
+  'euler_mapgrid',
   'burgers',
   'vc_advection',
 ]


### PR DESCRIPTION
The modules `euler_mapgrid_3D` and `mappedGrid` are built at installation.

`euler_mapgrid_3D` is compiled from 'rpn3_euler_mapgrid.f90', `rpt3_euler_mapgrid.f90`, and `rptt3_euler_mapgrid.f90`, and `mappedGrid` from `euler3d_mappedGrid.f90`.

These changes are discussed in clawpack/pyclaw#721 and clawpack/pyclaw#723.