### PR TITLE
revert change in the geoclaw_riemann_utils so fw(3,2) is used

### DIFF
--- a/src/geoclaw_riemann_utils.f
+++ b/src/geoclaw_riemann_utils.f
@@ -277,13 +277,14 @@ c        !solve for beta(k) using Cramers Rule=================
       ! MODIFIED from 5.3.1 version
       fw(3,1)=fw(3,1)*vL
       fw(3,3)=fw(3,3)*vR
-      fw(3,2) = (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+      fw(3,2)= 0.d0
  
-      !hustar_interface = huL + fw(1,1)   ! = huR - fw(1,3)
-      ! testing for dry middle state
-      !if (hustar_interface <= 0.0d0) then
-      !    fw(3,2) = 0.d0
-      !end if
+      hustar_interface = huL + fw(1,1)   ! = huR - fw(1,3)
+      if (hustar_interface <= 0.0d0) then
+          fw(3,1) = fw(3,1) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+        else
+          fw(3,3) = fw(3,3) + (hR*uR*vR - hL*uL*vL - fw(3,1)- fw(3,3))
+        end if
 
 
       return


### PR DESCRIPTION
This change was made in commit 4340757 and released in v5.13.0 to improve the order of accuracy on some test problems, but then it was found to give streaks in velocity on some practical problems. Reviewing the git history, this was seen earlier, and the code that we are reverting to in this commit was added in 2016 (in commit 9c02ede) to fix this problem.

More work is required to see if there's a different fix that improves the order of accuracy on smooth problems without introducing other problems.